### PR TITLE
Fix security issues and major bugs

### DIFF
--- a/api/apis/authApi.js
+++ b/api/apis/authApi.js
@@ -76,12 +76,19 @@ module.exports = function (app, url, passport, GoogleStrategy) {
             let user = req.user;
 
             if (!user) {
-                console.log('/auth/google/callback ==> USER NOT FOUND: ' + info.message);
-                var message = encodeURIComponent(info.message);
+                var message = encodeURIComponent('Authentication failed');
                 return res.redirect('/login?error=' + message);
             }
 
-            return res.redirect('/?id=' + user.id + '&email=' + user.email + '&token=' + user.accessToken + '&name=' + user.name + '&photo=' + user.photo);
+            var params = [
+                'id=' + encodeURIComponent(user.id),
+                'email=' + encodeURIComponent(user.email),
+                'token=' + encodeURIComponent(user.accessToken),
+                'name=' + encodeURIComponent(user.name),
+                'photo=' + encodeURIComponent(user.photo)
+            ].join('&');
+
+            return res.redirect('/#' + params);
         });
 
 }

--- a/api/apis/expensesApi.js
+++ b/api/apis/expensesApi.js
@@ -50,7 +50,7 @@ module.exports = function (app, url) {
     })
 
     app.delete('/api/expenses/:id', utils.ensureAuth, ensureExpenseUser, function (req, res) {
-        expensesService.delete({ _id: req.params.id },
+        expensesService.delete(req.params.id,
             function () {
                 res.json('OK');
             },

--- a/api/apis/incomesApi.js
+++ b/api/apis/incomesApi.js
@@ -50,7 +50,7 @@ module.exports = function (app, url) {
     })
 
     app.delete('/api/incomes/:id', utils.ensureAuth, ensureIncomeUser, function (req, res) {
-        incomesService.delete({ _id: req.params.id },
+        incomesService.delete(req.params.id,
             function () {
                 res.json('OK');
             },

--- a/api/apis/loansApi.js
+++ b/api/apis/loansApi.js
@@ -50,7 +50,7 @@ module.exports = function (app, url) {
     })
 
     app.delete('/api/loans/:id', utils.ensureAuth, ensureLoanUser, function (req, res) {
-        loansService.delete({ _id: req.params.id },
+        loansService.delete(req.params.id,
             function () {
                 res.json('OK');
             },

--- a/api/apis/transfersApi.js
+++ b/api/apis/transfersApi.js
@@ -50,7 +50,7 @@ module.exports = function (app, url) {
     })
 
     app.delete('/api/transfers/:id', utils.ensureAuth, ensureTransferUser, function (req, res) {
-        transfersService.delete({ _id: req.params.id },
+        transfersService.delete(req.params.id,
             function () {
                 res.json('OK');
             },

--- a/api/apis/usersApi.js
+++ b/api/apis/usersApi.js
@@ -39,7 +39,7 @@ module.exports = function (app, url) {
     })
 
     app.delete('/api/users/:id', utils.ensureAuthAdmin, utils.ensureAffectedUserIsNotAdmin, function (req, res) {
-        usersService.delete({ _id: req.params.id },
+        usersService.delete(req.params.id,
             function () {
                 res.json('OK');
             },

--- a/api/services/utilsService.js
+++ b/api/services/utilsService.js
@@ -5,11 +5,21 @@ var usersService = require('./usersService');
 var usersApiAdminEmail = process.env.USERS_API_ADMIN_EMAIL;
 
 var sendError = function (res, error, status) {
-	if (status) {
-		res.status(status).end('Error: ' + error);
+	var statusCode = status || 500;
+	var safeMessage;
+
+	if (statusCode >= 500) {
+		safeMessage = 'Internal server error';
+		console.error('sendError ==> ', error);
+	} else if (typeof error === 'string') {
+		safeMessage = error;
+	} else if (error && error.message) {
+		safeMessage = error.message;
 	} else {
-		res.status(500).end(error);
-	};
+		safeMessage = 'Request failed';
+	}
+
+	res.status(statusCode).json({ error: safeMessage });
 }
 
 var ensureAuth = function (req, res, next) {

--- a/server.js
+++ b/server.js
@@ -13,11 +13,15 @@ var GoogleStrategy = require('passport-google-oauth').OAuth2Strategy;
 
 // Configuration ===============================================================
 var promise = mongoose.connect(databaseUrl, { useNewUrlParser: true, useUnifiedTopology: true, retryWrites: false });
+
+app.set('trust proxy', 1);
+app.disable('x-powered-by');
+
 app.use(express.static(__dirname + '/static'))
 app.use(morgan('dev'));
-app.use(bodyParser.urlencoded({'extended':'true'}));
-app.use(bodyParser.json());
-app.use(bodyParser.json({ type: 'application/vnd.api+json' }));
+app.use(bodyParser.urlencoded({ extended: true, limit: '1mb' }));
+app.use(bodyParser.json({ limit: '1mb' }));
+app.use(bodyParser.json({ type: 'application/vnd.api+json', limit: '1mb' }));
 app.use(methodOverride('X-HTTP-Method-Override'));
 app.use(passport.initialize());
 

--- a/static/js/controllers/indexController.js
+++ b/static/js/controllers/indexController.js
@@ -2,33 +2,50 @@
 
 var app = angular.module('financeControl');
 
-app.controller('indexController', function ($scope, $localStorage, $routeParams, $location, Utils) {
+app.controller('indexController', function ($scope, $localStorage, $routeParams, $location, $window, Utils) {
 
 	$scope.isLoggedIn = function () {
 		return ($localStorage.get('loggedUserToken') != undefined) && ($localStorage.get('loggedUserToken').length > 0);
 	}
 
-	$scope.$on('$routeChangeSuccess', function () {
-		var loggedUserId = $routeParams.id;
-		var loggedUserEmail = $routeParams.email;
-		var loggedUserToken = $routeParams.token;
-		var loggedUserName = $routeParams.name;
-		var loggedUserPhoto = $routeParams.photo;
+	function parseHashParams(hash) {
+		var params = {};
+		if (!hash) return params;
+		if (hash.charAt(0) === '#') hash = hash.slice(1);
+		hash.split('&').forEach(function (pair) {
+			var idx = pair.indexOf('=');
+			if (idx === -1) return;
+			var key = decodeURIComponent(pair.slice(0, idx));
+			var value = decodeURIComponent(pair.slice(idx + 1));
+			params[key] = value;
+		});
+		return params;
+	}
 
-		if ((loggedUserId != undefined && loggedUserId.length > 0) && (loggedUserToken != undefined && loggedUserToken.length > 0)) {
-			$location.search('').replace();
+	function consumeLoginHash() {
+		var rawHash = $window.location.hash || $location.hash();
+		var hashParams = parseHashParams(rawHash);
 
-			$localStorage.set('loggedUserId', loggedUserId);
-			$localStorage.set('loggedUserEmail', loggedUserEmail);
-			$localStorage.set('loggedUserToken', loggedUserToken);
-			$localStorage.set('loggedUserName', loggedUserName);
-			$localStorage.set('loggedUserPhoto', loggedUserPhoto);
+		if (hashParams.id && hashParams.token) {
+			$localStorage.set('loggedUserId', hashParams.id);
+			$localStorage.set('loggedUserEmail', hashParams.email || '');
+			$localStorage.set('loggedUserToken', hashParams.token);
+			$localStorage.set('loggedUserName', hashParams.name || '');
+			$localStorage.set('loggedUserPhoto', hashParams.photo || '');
 
-			$scope.loggedUserName = loggedUserName;
-			$scope.loggedUserPhoto = loggedUserPhoto;
+			$scope.loggedUserName = hashParams.name || '';
+			$scope.loggedUserPhoto = hashParams.photo || '';
 			$scope.loggedIn = $scope.isLoggedIn();
+
+			if ($window.history && $window.history.replaceState) {
+				$window.history.replaceState(null, '', $window.location.pathname + $window.location.search);
+			}
+			$location.hash('');
 		}
-	});
+	}
+
+	consumeLoginHash();
+	$scope.$on('$routeChangeSuccess', consumeLoginHash);
 
 	$scope.changeRoute = function (newRoute) {
 		// If current Route is Home, and NewRoute is not Home, and is not the First Route Change


### PR DESCRIPTION
- authApi: stop crash on failed OAuth (undefined info.message)
- authApi/indexController: move login params from URL query to fragment so the access token is no longer logged or kept in browser history
- *Api: pass id directly to delete services (was wrapping in {_id: id}, producing {_id: {_id: ...}} which never matched)
- utilsService: sanitize sendError; hide stack traces on 5xx, return JSON
- server: disable x-powered-by, add 1MB body-parser limit, trust proxy