### PR TITLE
Build Vue frontend inside Docker image (multi-stage)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 .DS_Store
 node_modules
 web/node_modules
+web/dist
 backups
 docs
 *.md

--- a/docker-compose-server.yml
+++ b/docker-compose-server.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   web:  
     build:

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,12 +1,19 @@
-FROM node:20
+# Build the Vue frontend in a separate stage so prod images don't depend
+# on a host-built web/dist (Portainer just clones + composes).
+FROM node:20 AS web-builder
+WORKDIR /web
+COPY web/package.json web/.npmrc ./
+RUN npm install
+COPY web/ ./
+RUN npm run build
 
+FROM node:20
 WORKDIR /web
 
-# Install app dependencies
 COPY package*.json ./
 RUN npm install
 
-# Bundle app source (must include pre-built web/dist; run `npm --prefix web run build` first)
 COPY . .
+COPY --from=web-builder /web/dist ./web/dist
 
 CMD [ "node", "server.js" ]


### PR DESCRIPTION
Portainer pulls the repo and runs `docker compose up`, so prod has no host pre-build step. web/dist is gitignored, which meant the Vue Categories UI never shipped to prod. Add a web-builder stage to the Dockerfile that runs `vite build`, then COPY web/dist into the runtime image. Drop the obsolete `version: '3.1'` key from the server compose file, and exclude web/dist from the Docker context so a stale local build cannot leak into the image.