### PR TITLE
Migrate Expenses screen to Vue 3 + PrimeVue (strangler pattern)

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -113,7 +113,7 @@
 					<ul ng-show="loggedIn" class="nav navbar-nav navbar-right">
 						<li ng-show="Utils.isUltraHighResolution()"><a href="" ng-click="changeRoute('/')"><i
 									class="fa fa-home fa-lg"></i> Home</a></li>
-						<li><a href="" ng-click="changeRoute('/expenses')"><i class="fa fa-minus-square fa-lg"></i>
+						<li><a href="/app/expenses"><i class="fa fa-minus-square fa-lg"></i>
 								Despesas</a></li>
 						<li><a href="/app/incomes"><i class="fa fa-plus-square fa-lg"></i>
 								Receitas</a></li>

--- a/web/src/components/AppNavbar.vue
+++ b/web/src/components/AppNavbar.vue
@@ -67,7 +67,7 @@ interface NavItem extends MenuItem {
 }
 
 const items = ref<NavItem[]>([
-  { label: 'Despesas', icon: 'pi pi-minus-circle', url: '/expenses' },
+  { label: 'Despesas', icon: 'pi pi-minus-circle', to: '/expenses' },
   { label: 'Receitas', icon: 'pi pi-plus-circle', to: '/incomes' },
   { label: 'Transferências', icon: 'pi pi-arrows-h', url: '/transfers' },
   { label: 'Empréstimos', icon: 'pi pi-dollar', url: '/loans' },

--- a/web/src/composables/useExpenses.ts
+++ b/web/src/composables/useExpenses.ts
@@ -1,0 +1,134 @@
+import { ref } from 'vue';
+import api from '../lib/api';
+import type { Account, Currency, CategoryRef } from './useReferenceData';
+
+export type ExpenseStatus = 'Em aberto' | 'Pago';
+
+export interface ExpenseDetail {
+  _id?: string;
+  description: string;
+  amount: number;
+  account_id: string;
+  category_id: string;
+  currency_id: string;
+  status: ExpenseStatus;
+  _account?: Account;
+  _category?: CategoryRef;
+  _currency?: Currency;
+  _key?: string;
+}
+
+export interface Expense {
+  _id: string;
+  description: string;
+  dueDate: string;
+  scheduledPayment?: boolean;
+  amount: number;
+  amountPaid: number;
+  status: ExpenseStatus;
+  notes?: string;
+  user_id?: string;
+  account_id?: string | null;
+  category_id?: string | null;
+  currency_id?: string | null;
+  _account?: Account | null;
+  _category?: CategoryRef | null;
+  _currency?: Currency | null;
+  _accountNames?: string;
+  _categoryNames?: string;
+  _currencyCodes?: string;
+  detail: ExpenseDetail[];
+}
+
+export type ExpenseFormPayload = Omit<
+  Expense,
+  '_id' | '_account' | '_category' | '_currency' | '_accountNames' | '_categoryNames' | '_currencyCodes'
+> & {
+  _id?: string | null;
+};
+
+export interface BalanceResponse {
+  current: {
+    all: {
+      partialBalance: number;
+    };
+  };
+}
+
+export function compareDetails(a: ExpenseDetail, b: ExpenseDetail): number {
+  if (a.description < b.description) return -1;
+  if (a.description > b.description) return 1;
+  return 0;
+}
+
+export function useExpenses() {
+  const rows = ref<Expense[]>([]);
+  const loading = ref(false);
+  const selected = ref<Expense | null>(null);
+  const balance = ref<number>(0);
+
+  function buildDateFilter(begin: Date, end: Date): string {
+    const y1 = begin.getFullYear();
+    const m1 = begin.getMonth();
+    const d1 = begin.getDate();
+    const startDate = new Date(y1, m1, d1);
+
+    const y2 = end.getFullYear();
+    const m2 = end.getMonth();
+    const d2 = end.getDate();
+    const endDate = new Date(y2, m2, d2, 23, 59, 59, 999);
+
+    return `dateBegin=${startDate.toString()}&dateEnd=${endDate.toString()}`;
+  }
+
+  async function fetchAll(begin: Date, end: Date) {
+    loading.value = true;
+    try {
+      const filter = buildDateFilter(begin, end);
+      const [expensesResp, balanceResp] = await Promise.all([
+        api.get<Expense[]>(`/expenses?${filter}`),
+        api.get<BalanceResponse>(`/totals/balance?${filter}`),
+      ]);
+      rows.value = expensesResp.data;
+      balance.value = balanceResp.data?.current?.all?.partialBalance ?? 0;
+      selected.value = null;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function getById(id: string): Promise<Expense> {
+    const { data } = await api.get<Expense>(`/expenses/${id}`);
+    return data;
+  }
+
+  async function create(expense: ExpenseFormPayload): Promise<void> {
+    await api.post('/expenses', expense);
+  }
+
+  async function update(expense: ExpenseFormPayload): Promise<void> {
+    if (!expense._id) throw new Error('Expense id is required for update');
+    await api.patch(`/expenses/${expense._id}`, expense);
+  }
+
+  async function remove(id: string): Promise<void> {
+    await api.delete(`/expenses/${id}`);
+  }
+
+  async function pay(id: string): Promise<void> {
+    await api.patch(`/expenses/${id}?pay=true`);
+  }
+
+  return {
+    rows,
+    loading,
+    selected,
+    balance,
+    fetchAll,
+    getById,
+    create,
+    update,
+    remove,
+    pay,
+  };
+}

--- a/web/src/router.ts
+++ b/web/src/router.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import CategoriesView from './views/CategoriesView.vue';
 import IncomesView from './views/IncomesView.vue';
+import ExpensesView from './views/ExpensesView.vue';
 
 const router = createRouter({
   history: createWebHistory('/app/'),
@@ -8,6 +9,7 @@ const router = createRouter({
     { path: '/', redirect: '/categories' },
     { path: '/categories', name: 'categories', component: CategoriesView },
     { path: '/incomes', name: 'incomes', component: IncomesView },
+    { path: '/expenses', name: 'expenses', component: ExpensesView },
   ],
 });
 

--- a/web/src/views/ExpensesView.vue
+++ b/web/src/views/ExpensesView.vue
@@ -1,0 +1,432 @@
+<template>
+  <div class="container mx-auto px-4 py-6">
+    <h1 class="text-xl font-semibold mb-4">Cadastro de despesas</h1>
+
+    <Toolbar class="mb-4">
+      <template #start>
+        <div class="flex gap-2 flex-wrap">
+          <Button
+            icon="pi pi-plus"
+            severity="primary"
+            size="small"
+            aria-label="Adicionar"
+            v-tooltip.bottom="'Adicionar'"
+            @click="openExpense('new', null)"
+          />
+          <Button
+            icon="pi pi-pencil"
+            severity="primary"
+            size="small"
+            :disabled="!selected"
+            aria-label="Editar"
+            v-tooltip.bottom="'Editar'"
+            @click="openExpense('edit', selected?._id ?? null)"
+          />
+          <Button
+            icon="pi pi-trash"
+            severity="primary"
+            size="small"
+            :disabled="!selected"
+            aria-label="Excluir"
+            v-tooltip.bottom="'Excluir'"
+            @click="confirmDelete"
+          />
+          <Button
+            icon="pi pi-clone"
+            severity="primary"
+            size="small"
+            :disabled="!selected"
+            aria-label="Clonar"
+            v-tooltip.bottom="'Clonar'"
+            @click="openExpense('clone', selected?._id ?? null)"
+          />
+          <Button
+            icon="pi pi-dollar"
+            severity="primary"
+            size="small"
+            :disabled="!selected || selected.status !== 'Em aberto'"
+            aria-label="Pagar"
+            v-tooltip.bottom="'Pagar'"
+            @click="confirmPay"
+          />
+          <Button
+            icon="pi pi-cog"
+            severity="primary"
+            size="small"
+            aria-label="Gerar"
+            v-tooltip.bottom="'Gerar'"
+            @click="generatorVisible = true"
+          />
+        </div>
+      </template>
+
+      <template #center>
+        <div class="flex flex-wrap items-center gap-2">
+          <Button
+            size="small"
+            severity="success"
+            v-tooltip.bottom="'Ir para o início do ano'"
+            label="<<"
+            @click="navigate('beginYear')"
+          />
+          <Button
+            size="small"
+            severity="success"
+            v-tooltip.bottom="'Ir para o mês anterior'"
+            label="-1 Mês"
+            @click="navigate('prev')"
+          />
+          <Button
+            size="small"
+            severity="success"
+            v-tooltip.bottom="'Ir para o mês atual'"
+            label="Atual"
+            @click="navigate('actual')"
+          />
+          <Button
+            size="small"
+            severity="success"
+            v-tooltip.bottom="'Ir para o próximo mês'"
+            label="+1 Mês"
+            @click="navigate('next')"
+          />
+          <Button
+            size="small"
+            severity="success"
+            v-tooltip.bottom="'Ir para o fim do ano'"
+            label=">>"
+            @click="navigate('endYear')"
+          />
+        </div>
+      </template>
+
+      <template #end>
+        <div class="flex flex-wrap items-center gap-2">
+          <DatePicker
+            v-model="dueDateBegin"
+            date-format="dd/mm/yy"
+            show-icon
+            input-class="!w-32"
+          />
+          <DatePicker
+            v-model="dueDateEnd"
+            date-format="dd/mm/yy"
+            show-icon
+            input-class="!w-32"
+          />
+          <Button label="Filtrar" size="small" severity="secondary" @click="fetchAll" />
+          <div class="flex flex-col items-end ml-4">
+            <span class="text-xs text-slate-500 leading-none">Saldo</span>
+            <span :class="['font-semibold leading-tight', balanceClass]">{{
+              formatNumber(balance)
+            }}</span>
+          </div>
+        </div>
+      </template>
+    </Toolbar>
+
+    <DataTable
+      v-model:selection="selected"
+      :value="rows"
+      :loading="loading"
+      data-key="_id"
+      selection-mode="single"
+      removable-sort
+      striped-rows
+      :paginator="rows.length > 25"
+      :rows="25"
+      :row-class="rowClass"
+      class="p-datatable-sm"
+    >
+      <Column field="dueDate" header="Vencimento" sortable style="width: 9rem" class="text-center">
+        <template #body="{ data }">{{ formatShortDate(data.dueDate) }}</template>
+      </Column>
+      <Column field="description" header="Descrição" sortable>
+        <template #footer>{{ rows.length }} registros</template>
+      </Column>
+      <Column
+        field="_currencyCodes"
+        header="Moeda"
+        sortable
+        style="width: 6rem"
+        class="text-center"
+      />
+      <Column
+        field="amount"
+        header="Valor"
+        sortable
+        style="width: 9rem"
+        header-class="!justify-end"
+      >
+        <template #body="{ data }">
+          <span class="block text-right">{{ formatNumber(data.amount) }}</span>
+        </template>
+        <template #footer>
+          <span class="block text-right">{{ formatNumber(amountTotal) }}</span>
+        </template>
+      </Column>
+      <Column field="_accountNames" header="Conta" sortable style="width: 12rem" />
+      <Column field="_categoryNames" header="Categoria" sortable style="width: 12rem" />
+      <Column field="status" header="Situação" sortable style="width: 8rem" class="text-center" />
+      <Column
+        field="amountPaid"
+        header="Valor pago"
+        sortable
+        style="width: 9rem"
+        header-class="!justify-end"
+      >
+        <template #body="{ data }">
+          <span class="block text-right">{{ formatNumber(data.amountPaid) }}</span>
+        </template>
+        <template #footer>
+          <span class="block text-right">{{ formatNumber(amountPaidTotal) }}</span>
+        </template>
+      </Column>
+      <Column header="Ag." style="width: 4rem" class="text-center">
+        <template #body="{ data }">
+          <i v-if="data.scheduledPayment" class="pi pi-check text-slate-600" />
+        </template>
+      </Column>
+      <template #empty>Nenhuma despesa encontrada.</template>
+    </DataTable>
+
+    <ExpenseFormDialog
+      :visible="expenseDialog.visible"
+      :mode="expenseDialog.mode"
+      :expense-id="expenseDialog.expenseId"
+      @submit="onExpenseSubmit"
+      @close="closeExpenseDialog"
+      @load-error="onLoadError"
+    />
+
+    <GeneratorFormDialog
+      :visible="generatorVisible"
+      @submit="onGeneratorSubmit"
+      @close="generatorVisible = false"
+      @load-error="onLoadError"
+      @save-error="onSaveError"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref } from 'vue';
+import DataTable from 'primevue/datatable';
+import Column from 'primevue/column';
+import Button from 'primevue/button';
+import Toolbar from 'primevue/toolbar';
+import DatePicker from 'primevue/datepicker';
+import { useToast } from 'primevue/usetoast';
+import { useConfirm } from 'primevue/useconfirm';
+import {
+  useExpenses,
+  type Expense,
+  type ExpenseFormPayload,
+} from '../composables/useExpenses';
+import {
+  formatNumber,
+  formatShortDate,
+  getActualMonth,
+  getBeginOfYear,
+  getEndOfYear,
+  getNextMonth,
+  getPreviousMonth,
+  isLatePayment,
+} from '../lib/dateUtils';
+import ExpenseFormDialog from './expenses/ExpenseFormDialog.vue';
+import GeneratorFormDialog from './expenses/GeneratorFormDialog.vue';
+
+const toast = useToast();
+const confirm = useConfirm();
+
+const { rows, loading, selected, balance, fetchAll: fetchExpenses, create, update, remove, pay } =
+  useExpenses();
+
+const { begin: initialBegin, end: initialEnd } = getActualMonth();
+const dueDateBegin = ref<Date | null>(initialBegin);
+const dueDateEnd = ref<Date | null>(initialEnd);
+
+const generatorVisible = ref(false);
+
+const expenseDialog = reactive<{ visible: boolean; mode: 'new' | 'edit' | 'clone'; expenseId: string | null }>({
+  visible: false,
+  mode: 'new',
+  expenseId: null,
+});
+
+const amountTotal = computed(() => rows.value.reduce((acc, r) => acc + (r.amount ?? 0), 0));
+const amountPaidTotal = computed(() =>
+  rows.value.reduce((acc, r) => acc + (r.amountPaid ?? 0), 0),
+);
+const balanceClass = computed(() => {
+  if (balance.value < 0) return 'text-red-600';
+  if (balance.value === 0) return 'text-slate-500';
+  return 'text-green-600';
+});
+
+onMounted(fetchAll);
+
+async function fetchAll() {
+  if (!dueDateBegin.value || !dueDateEnd.value) return;
+  try {
+    await fetchExpenses(dueDateBegin.value, dueDateEnd.value);
+  } catch (err) {
+    onLoadError(extractStatus(err));
+  }
+}
+
+function rowClass(data: Expense): string {
+  return isLatePayment(data.status === 'Em aberto', data.dueDate) ? 'late-payment' : '';
+}
+
+function navigate(target: 'beginYear' | 'prev' | 'actual' | 'next' | 'endYear') {
+  const base = dueDateBegin.value ?? new Date();
+  let range;
+  switch (target) {
+    case 'beginYear':
+      range = getBeginOfYear(base);
+      break;
+    case 'prev':
+      range = getPreviousMonth(base);
+      break;
+    case 'actual':
+      range = getActualMonth();
+      break;
+    case 'next':
+      range = getNextMonth(base);
+      break;
+    case 'endYear':
+      range = getEndOfYear(base);
+      break;
+  }
+  dueDateBegin.value = range.begin;
+  dueDateEnd.value = range.end;
+  fetchAll();
+}
+
+function openExpense(mode: 'new' | 'edit' | 'clone', id: string | null) {
+  if ((mode === 'edit' || mode === 'clone') && !id) return;
+  expenseDialog.mode = mode;
+  expenseDialog.expenseId = id;
+  expenseDialog.visible = true;
+}
+
+function closeExpenseDialog() {
+  expenseDialog.visible = false;
+}
+
+async function onExpenseSubmit(
+  payload: ExpenseFormPayload,
+  mode: 'new' | 'edit' | 'clone',
+) {
+  closeExpenseDialog();
+  try {
+    if (mode === 'edit') {
+      await update(payload);
+      toast.add({
+        severity: 'success',
+        summary: 'Despesa editada com sucesso!',
+        life: 4000,
+      });
+    } else {
+      await create(payload);
+      toast.add({
+        severity: 'success',
+        summary: 'Despesa adicionada com sucesso!',
+        life: 4000,
+      });
+    }
+    await fetchAll();
+  } catch (err) {
+    onSaveError(extractStatus(err));
+  }
+}
+
+function onGeneratorSubmit() {
+  generatorVisible.value = false;
+  toast.add({
+    severity: 'success',
+    summary: 'Despesa(s) gerada(s) com sucesso!',
+    life: 4000,
+  });
+  fetchAll();
+}
+
+function confirmDelete() {
+  if (!selected.value) return;
+  const id = selected.value._id;
+  confirm.require({
+    message: 'Confirma a exclusão da despesa?',
+    header: 'Excluir despesa',
+    rejectProps: { label: 'Cancelar', severity: 'secondary', text: true },
+    acceptProps: { label: 'Confirmar' },
+    accept: async () => {
+      try {
+        await remove(id);
+        toast.add({
+          severity: 'success',
+          summary: 'Despesa excluída com sucesso!',
+          life: 4000,
+        });
+        await fetchAll();
+      } catch (err) {
+        onSaveError(extractStatus(err));
+      }
+    },
+  });
+}
+
+function confirmPay() {
+  if (!selected.value) return;
+  const id = selected.value._id;
+  confirm.require({
+    message: 'Confirma o pagamento da despesa?',
+    header: 'Pagar despesa',
+    rejectProps: { label: 'Cancelar', severity: 'secondary', text: true },
+    acceptProps: { label: 'Confirmar' },
+    accept: async () => {
+      try {
+        await pay(id);
+        toast.add({
+          severity: 'success',
+          summary: 'Despesa paga com sucesso!',
+          life: 4000,
+        });
+        await fetchAll();
+      } catch (err) {
+        onSaveError(extractStatus(err));
+      }
+    },
+  });
+}
+
+function onLoadError(status: number | string) {
+  toast.add({
+    severity: 'error',
+    summary: `Erro ao carregar os dados: ${status}`,
+    life: 6000,
+  });
+}
+
+function onSaveError(status: number | string) {
+  toast.add({
+    severity: 'error',
+    summary: `Erro ao salvar os dados: ${status}`,
+    life: 6000,
+  });
+}
+
+function extractStatus(err: unknown): number | string {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const r = (err as { response?: { status?: number } }).response;
+    return r?.status ?? 'erro';
+  }
+  return 'erro';
+}
+</script>
+
+<style>
+.late-payment td {
+  color: #b91c1c;
+}
+</style>

--- a/web/src/views/expenses/ExpenseDetailFormDialog.vue
+++ b/web/src/views/expenses/ExpenseDetailFormDialog.vue
@@ -1,0 +1,273 @@
+<template>
+  <Dialog
+    :visible="visible"
+    :header="title"
+    modal
+    :style="{ width: 'min(34rem, 92vw)' }"
+    :closable="false"
+    @update:visible="handleClose"
+  >
+    <div v-if="loading" class="flex justify-center py-8">
+      <ProgressSpinner style="width: 3rem; height: 3rem" />
+    </div>
+
+    <form v-else class="flex flex-col gap-4" @submit.prevent="handleSubmit">
+      <div class="flex flex-col gap-1">
+        <label for="expenseDetailDescription" class="text-sm font-medium">Descrição</label>
+        <InputText
+          id="expenseDetailDescription"
+          v-model="form.description"
+          :invalid="submitted && !!errors.description"
+          autofocus
+          maxlength="100"
+        />
+        <small v-if="submitted && errors.description" class="text-red-600">{{
+          errors.description
+        }}</small>
+      </div>
+
+      <div class="grid grid-cols-12 gap-3">
+        <div class="col-span-4 flex flex-col gap-1">
+          <label for="expenseDetailCurrency" class="text-sm font-medium">Moeda</label>
+          <Select
+            id="expenseDetailCurrency"
+            v-model="form.currency_id"
+            :options="currencies"
+            option-label="currencyCode"
+            option-value="_id"
+            :invalid="submitted && !!errors.currency_id"
+            placeholder="Moeda"
+          />
+          <small v-if="submitted && errors.currency_id" class="text-red-600">{{
+            errors.currency_id
+          }}</small>
+        </div>
+        <div class="col-span-8 flex flex-col gap-1">
+          <label for="expenseDetailAmount" class="text-sm font-medium">Valor</label>
+          <InputNumber
+            id="expenseDetailAmount"
+            v-model="form.amount"
+            :min-fraction-digits="2"
+            :max-fraction-digits="2"
+            :invalid="submitted && !!errors.amount"
+            locale="pt-BR"
+            input-class="text-right"
+          />
+          <small v-if="submitted && errors.amount" class="text-red-600">{{ errors.amount }}</small>
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <label for="expenseDetailAccount" class="text-sm font-medium">Conta</label>
+        <Select
+          id="expenseDetailAccount"
+          v-model="form.account_id"
+          :options="accounts"
+          option-label="name"
+          option-value="_id"
+          :invalid="submitted && !!errors.account_id"
+          placeholder="Selecione"
+        />
+        <small v-if="submitted && errors.account_id" class="text-red-600">{{
+          errors.account_id
+        }}</small>
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <label for="expenseDetailCategory" class="text-sm font-medium">Categoria</label>
+        <Select
+          id="expenseDetailCategory"
+          v-model="form.category_id"
+          :options="categories"
+          option-label="name"
+          option-value="_id"
+          :invalid="submitted && !!errors.category_id"
+          placeholder="Selecione"
+        />
+        <small v-if="submitted && errors.category_id" class="text-red-600">{{
+          errors.category_id
+        }}</small>
+      </div>
+
+      <div class="flex flex-col gap-1 max-w-[14rem]">
+        <label for="expenseDetailStatus" class="text-sm font-medium">Situação</label>
+        <Select
+          id="expenseDetailStatus"
+          v-model="form.status"
+          :options="expenseStatusOptions"
+          :invalid="submitted && !!errors.status"
+          placeholder="Selecione"
+        />
+        <small v-if="submitted && errors.status" class="text-red-600">{{ errors.status }}</small>
+      </div>
+    </form>
+
+    <template #footer>
+      <Button label="Cancelar" severity="secondary" text @click="handleClose" />
+      <Button label="Confirmar" :disabled="loading" @click="handleSubmit" />
+    </template>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref, watch } from 'vue';
+import Dialog from 'primevue/dialog';
+import InputText from 'primevue/inputtext';
+import InputNumber from 'primevue/inputnumber';
+import Select from 'primevue/select';
+import Button from 'primevue/button';
+import ProgressSpinner from 'primevue/progressspinner';
+import type { ExpenseDetail, ExpenseStatus } from '../../composables/useExpenses';
+import {
+  useReferenceData,
+  type Account,
+  type CategoryRef,
+  type Currency,
+} from '../../composables/useReferenceData';
+
+type Mode = 'new' | 'edit' | 'clone';
+
+const props = defineProps<{
+  visible: boolean;
+  mode: Mode;
+  detail: ExpenseDetail | null;
+}>();
+
+const emit = defineEmits<{
+  (e: 'submit', value: ExpenseDetail, mode: Mode, originalKey: string | null): void;
+  (e: 'close'): void;
+  (e: 'load-error', status: number | string): void;
+}>();
+
+const expenseStatusOptions: ExpenseStatus[] = ['Em aberto', 'Pago'];
+
+const { loadCurrencies, loadAccounts, loadCategories, getDefaultCurrencyId } = useReferenceData();
+
+const loading = ref(false);
+const submitted = ref(false);
+const currencies = ref<Currency[]>([]);
+const accounts = ref<Account[]>([]);
+const categories = ref<CategoryRef[]>([]);
+
+const form = reactive<{
+  _id?: string;
+  description: string;
+  amount: number | null;
+  account_id: string;
+  category_id: string;
+  currency_id: string;
+  status: ExpenseStatus;
+}>({
+  _id: undefined,
+  description: '',
+  amount: null,
+  account_id: '',
+  category_id: '',
+  currency_id: '',
+  status: 'Em aberto',
+});
+
+const originalKey = ref<string | null>(null);
+
+const title = computed(() => {
+  if (props.mode === 'new') return 'Adicionar detalhe';
+  if (props.mode === 'clone') return 'Clonar detalhe';
+  return 'Editar detalhe';
+});
+
+const errors = computed<Record<string, string>>(() => {
+  const out: Record<string, string> = {};
+  const desc = form.description?.trim() ?? '';
+  if (!desc) out.description = 'O campo Descrição é obrigatório.';
+  else if (desc.length > 100)
+    out.description = 'O campo Descrição deve possuir no máximo 100 caracteres.';
+  if (!form.currency_id) out.currency_id = 'O campo Moeda é obrigatório.';
+  if (!form.amount || form.amount <= 0) out.amount = 'O campo Valor é obrigatório.';
+  if (!form.account_id) out.account_id = 'O campo Conta é obrigatório.';
+  if (!form.category_id) out.category_id = 'O campo Categoria é obrigatório.';
+  if (!form.status) out.status = 'O campo Situação é obrigatório.';
+  return out;
+});
+
+watch(
+  () => [props.visible, props.mode] as const,
+  async ([visible, mode]) => {
+    if (!visible) return;
+    submitted.value = false;
+    loading.value = true;
+    try {
+      const [cur, acc, cat] = await Promise.all([
+        loadCurrencies(),
+        loadAccounts(),
+        loadCategories('Despesa'),
+      ]);
+      currencies.value = cur;
+      accounts.value = acc;
+      categories.value = cat;
+
+      if (mode === 'new') {
+        originalKey.value = null;
+        form._id = undefined;
+        form.description = '';
+        form.amount = null;
+        form.account_id = '';
+        form.category_id = '';
+        form.currency_id = getDefaultCurrencyId(cur);
+        form.status = 'Em aberto';
+      } else if (props.detail) {
+        originalKey.value = props.detail._key ?? null;
+        form._id = mode === 'clone' ? undefined : props.detail._id;
+        form.description =
+          mode === 'clone' ? `${props.detail.description} - Cópia` : props.detail.description;
+        form.amount = props.detail.amount;
+        form.account_id = props.detail.account_id;
+        form.category_id = props.detail.category_id;
+        form.currency_id = props.detail.currency_id;
+        form.status = props.detail.status;
+      }
+    } catch (err) {
+      emit('load-error', extractStatus(err));
+      emit('close');
+    } finally {
+      loading.value = false;
+    }
+  },
+  { immediate: true },
+);
+
+function handleSubmit() {
+  if (Object.keys(errors.value).length > 0) {
+    submitted.value = true;
+    return;
+  }
+  const account = accounts.value.find((a) => a._id === form.account_id);
+  const category = categories.value.find((c) => c._id === form.category_id);
+  const currency = currencies.value.find((c) => c._id === form.currency_id);
+
+  const payload: ExpenseDetail = {
+    _id: form._id,
+    description: form.description.trim(),
+    amount: form.amount as number,
+    account_id: form.account_id,
+    category_id: form.category_id,
+    currency_id: form.currency_id,
+    status: form.status,
+    _account: account,
+    _category: category,
+    _currency: currency,
+  };
+  emit('submit', payload, props.mode, originalKey.value);
+}
+
+function handleClose() {
+  emit('close');
+}
+
+function extractStatus(err: unknown): number | string {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const r = (err as { response?: { status?: number } }).response;
+    return r?.status ?? 'erro';
+  }
+  return 'erro';
+}
+</script>

--- a/web/src/views/expenses/ExpenseFormDialog.vue
+++ b/web/src/views/expenses/ExpenseFormDialog.vue
@@ -1,0 +1,606 @@
+<template>
+  <Dialog
+    :visible="visible"
+    :header="title"
+    modal
+    :style="{ width: 'min(56rem, 95vw)' }"
+    :closable="false"
+    @update:visible="handleClose"
+  >
+    <div v-if="loading" class="flex justify-center py-8">
+      <ProgressSpinner style="width: 3rem; height: 3rem" />
+    </div>
+
+    <form v-else class="flex flex-col gap-4" @submit.prevent="handleSubmit">
+      <div class="grid grid-cols-12 gap-3">
+        <div class="col-span-12 sm:col-span-8 flex flex-col gap-1">
+          <label for="expenseDescription" class="text-sm font-medium">Descrição</label>
+          <InputText
+            id="expenseDescription"
+            v-model="form.description"
+            :invalid="submitted && !!errors.description"
+            autofocus
+            maxlength="100"
+          />
+          <small v-if="submitted && errors.description" class="text-red-600">{{
+            errors.description
+          }}</small>
+        </div>
+        <div class="col-span-12 sm:col-span-4 flex items-end">
+          <div class="flex items-center gap-2 mb-1.5">
+            <Checkbox
+              v-model="form.scheduledPayment"
+              inputId="expenseScheduledPayment"
+              binary
+            />
+            <label for="expenseScheduledPayment" class="text-sm">Pagamento agendado</label>
+          </div>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-12 gap-3">
+        <div class="col-span-12 sm:col-span-4 flex flex-col gap-1">
+          <label for="expenseDueDate" class="text-sm font-medium">Vencimento</label>
+          <DatePicker
+            id="expenseDueDate"
+            v-model="form.dueDate"
+            date-format="dd/mm/yy"
+            show-icon
+            :invalid="submitted && !!errors.dueDate"
+          />
+          <small v-if="submitted && errors.dueDate" class="text-red-600">{{
+            errors.dueDate
+          }}</small>
+        </div>
+        <div class="col-span-4 sm:col-span-3 flex flex-col gap-1">
+          <label for="expenseCurrency" class="text-sm font-medium">Moeda</label>
+          <Select
+            id="expenseCurrency"
+            v-model="form.currency_id"
+            :options="currencies"
+            option-label="currencyCode"
+            option-value="_id"
+            :disabled="hasDetail"
+            :invalid="submitted && !!errors.currency_id"
+            placeholder="Moeda"
+          />
+          <small v-if="submitted && errors.currency_id" class="text-red-600">{{
+            errors.currency_id
+          }}</small>
+        </div>
+        <div class="col-span-8 sm:col-span-5 flex flex-col gap-1">
+          <label for="expenseAmount" class="text-sm font-medium">Valor</label>
+          <InputNumber
+            id="expenseAmount"
+            v-model="form.amount"
+            :min-fraction-digits="2"
+            :max-fraction-digits="2"
+            :readonly="hasDetail"
+            :invalid="submitted && !!errors.amount"
+            locale="pt-BR"
+            input-class="text-right"
+          />
+          <small v-if="submitted && errors.amount" class="text-red-600">{{ errors.amount }}</small>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-12 gap-3">
+        <div class="col-span-12 sm:col-span-6 flex flex-col gap-1">
+          <label for="expenseAccount" class="text-sm font-medium">Conta</label>
+          <Select
+            id="expenseAccount"
+            v-model="form.account_id"
+            :options="accounts"
+            option-label="name"
+            option-value="_id"
+            :disabled="hasDetail"
+            :invalid="submitted && !!errors.account_id"
+            placeholder="Selecione"
+          />
+          <small v-if="submitted && errors.account_id" class="text-red-600">{{
+            errors.account_id
+          }}</small>
+        </div>
+        <div class="col-span-12 sm:col-span-6 flex flex-col gap-1">
+          <label for="expenseCategory" class="text-sm font-medium">Categoria</label>
+          <Select
+            id="expenseCategory"
+            v-model="form.category_id"
+            :options="categories"
+            option-label="name"
+            option-value="_id"
+            :disabled="hasDetail"
+            :invalid="submitted && !!errors.category_id"
+            placeholder="Selecione"
+          />
+          <small v-if="submitted && errors.category_id" class="text-red-600">{{
+            errors.category_id
+          }}</small>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-12 gap-3">
+        <div class="col-span-12 sm:col-span-6 flex flex-col gap-1">
+          <label for="expenseStatus" class="text-sm font-medium">Situação</label>
+          <Select
+            id="expenseStatus"
+            v-model="form.status"
+            :options="expenseStatusOptions"
+            :disabled="hasDetail"
+            :invalid="submitted && !!errors.status"
+            placeholder="Selecione"
+            @change="onChangeStatus"
+          />
+          <small v-if="submitted && errors.status" class="text-red-600">{{ errors.status }}</small>
+        </div>
+        <div class="col-span-12 sm:col-span-6 flex flex-col gap-1">
+          <label for="expenseAmountPaid" class="text-sm font-medium">Valor pago</label>
+          <InputNumber
+            id="expenseAmountPaid"
+            v-model="form.amountPaid"
+            :min-fraction-digits="2"
+            :max-fraction-digits="2"
+            :readonly="hasDetail"
+            :invalid="submitted && !!errors.amountPaid"
+            locale="pt-BR"
+            input-class="text-right"
+          />
+          <small v-if="submitted && errors.amountPaid" class="text-red-600">{{
+            errors.amountPaid
+          }}</small>
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <label for="expenseNotes" class="text-sm font-medium">Observações</label>
+        <Textarea id="expenseNotes" v-model="form.notes" rows="2" />
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <Toolbar class="!p-2">
+          <template #start>
+            <div class="flex gap-2">
+              <Button
+                icon="pi pi-plus"
+                size="small"
+                aria-label="Adicionar"
+                v-tooltip.bottom="'Adicionar'"
+                @click="openDetail('new', null)"
+              />
+              <Button
+                icon="pi pi-pencil"
+                size="small"
+                :disabled="!selectedDetail"
+                aria-label="Editar"
+                v-tooltip.bottom="'Editar'"
+                @click="openDetail('edit', selectedDetail)"
+              />
+              <Button
+                icon="pi pi-trash"
+                size="small"
+                :disabled="!selectedDetail"
+                aria-label="Excluir"
+                v-tooltip.bottom="'Excluir'"
+                @click="confirmDeleteDetail"
+              />
+              <Button
+                icon="pi pi-clone"
+                size="small"
+                :disabled="!selectedDetail"
+                aria-label="Clonar"
+                v-tooltip.bottom="'Clonar'"
+                @click="openDetail('clone', selectedDetail)"
+              />
+              <Button
+                icon="pi pi-dollar"
+                size="small"
+                :disabled="!selectedDetail || selectedDetail.status !== 'Em aberto'"
+                aria-label="Pagar"
+                v-tooltip.bottom="'Pagar'"
+                @click="payDetail"
+              />
+            </div>
+          </template>
+        </Toolbar>
+
+        <DataTable
+          v-model:selection="selectedDetail"
+          :value="form.detail"
+          data-key="_key"
+          selection-mode="single"
+          striped-rows
+          class="p-datatable-sm"
+          :rows="5"
+        >
+          <Column field="description" header="Descrição">
+            <template #footer>{{ form.detail.length }} registros</template>
+          </Column>
+          <Column header="Moeda" style="width: 5rem" class="text-center">
+            <template #body="{ data }">{{ data._currency?.currencyCode ?? '' }}</template>
+          </Column>
+          <Column header="Valor" style="width: 8rem" class="text-right">
+            <template #body="{ data }">{{ formatNumber(data.amount) }}</template>
+            <template #footer>
+              <span class="block text-right">{{ formatNumber(detailTotal) }}</span>
+            </template>
+          </Column>
+          <Column header="Conta" style="width: 12rem">
+            <template #body="{ data }">{{ data._account?.name ?? '' }}</template>
+          </Column>
+          <Column header="Categoria" style="width: 12rem">
+            <template #body="{ data }">{{ data._category?.name ?? '' }}</template>
+          </Column>
+          <Column field="status" header="Situação" style="width: 8rem" class="text-center" />
+          <template #empty>
+            <div class="text-center text-sm text-slate-500 py-4">Nenhum detalhe adicionado.</div>
+          </template>
+        </DataTable>
+      </div>
+    </form>
+
+    <template #footer>
+      <Button label="Cancelar" severity="secondary" text @click="handleClose" />
+      <Button label="Confirmar" :disabled="loading" @click="handleSubmit" />
+    </template>
+  </Dialog>
+
+  <ExpenseDetailFormDialog
+    :visible="detailDialog.visible"
+    :mode="detailDialog.mode"
+    :detail="detailDialog.detail"
+    @submit="onDetailSubmit"
+    @close="closeDetailDialog"
+    @load-error="onDetailLoadError"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref, watch } from 'vue';
+import Dialog from 'primevue/dialog';
+import InputText from 'primevue/inputtext';
+import InputNumber from 'primevue/inputnumber';
+import Select from 'primevue/select';
+import Button from 'primevue/button';
+import Toolbar from 'primevue/toolbar';
+import Textarea from 'primevue/textarea';
+import Checkbox from 'primevue/checkbox';
+import DataTable from 'primevue/datatable';
+import Column from 'primevue/column';
+import DatePicker from 'primevue/datepicker';
+import ProgressSpinner from 'primevue/progressspinner';
+import { useConfirm } from 'primevue/useconfirm';
+import {
+  useExpenses,
+  compareDetails,
+  type Expense,
+  type ExpenseDetail,
+  type ExpenseFormPayload,
+  type ExpenseStatus,
+} from '../../composables/useExpenses';
+import {
+  useReferenceData,
+  type Account,
+  type CategoryRef,
+  type Currency,
+} from '../../composables/useReferenceData';
+import { formatNumber, getDateDst } from '../../lib/dateUtils';
+import ExpenseDetailFormDialog from './ExpenseDetailFormDialog.vue';
+
+type Mode = 'new' | 'edit' | 'clone';
+
+const props = defineProps<{
+  visible: boolean;
+  mode: Mode;
+  expenseId: string | null;
+}>();
+
+const emit = defineEmits<{
+  (e: 'submit', value: ExpenseFormPayload, mode: Mode): void;
+  (e: 'close'): void;
+  (e: 'load-error', status: number | string): void;
+}>();
+
+const expenseStatusOptions: ExpenseStatus[] = ['Em aberto', 'Pago'];
+
+const { getById } = useExpenses();
+const { loadCurrencies, loadAccounts, loadCategories, getDefaultCurrencyId } = useReferenceData();
+const confirm = useConfirm();
+
+const loading = ref(false);
+const submitted = ref(false);
+const currencies = ref<Currency[]>([]);
+const accounts = ref<Account[]>([]);
+const categories = ref<CategoryRef[]>([]);
+const loaded = ref<Expense | null>(null);
+
+const form = reactive<{
+  _id?: string;
+  description: string;
+  dueDate: Date | null;
+  scheduledPayment: boolean;
+  amount: number | null;
+  amountPaid: number | null;
+  currency_id: string;
+  account_id: string;
+  category_id: string;
+  status: ExpenseStatus;
+  notes: string;
+  detail: ExpenseDetail[];
+}>({
+  _id: undefined,
+  description: '',
+  dueDate: null,
+  scheduledPayment: false,
+  amount: null,
+  amountPaid: null,
+  currency_id: '',
+  account_id: '',
+  category_id: '',
+  status: 'Em aberto',
+  notes: '',
+  detail: [],
+});
+
+const selectedDetail = ref<ExpenseDetail | null>(null);
+
+const detailDialog = reactive<{ visible: boolean; mode: Mode; detail: ExpenseDetail | null }>({
+  visible: false,
+  mode: 'new',
+  detail: null,
+});
+
+const hasDetail = computed(() => form.detail.length > 0);
+
+const detailTotal = computed(() =>
+  form.detail.reduce((acc, d) => acc + (d.amount ?? 0), 0),
+);
+
+const title = computed(() => {
+  if (props.mode === 'new') return 'Adicionar despesa';
+  if (props.mode === 'clone') return 'Clonar despesa';
+  return 'Editar despesa';
+});
+
+const errors = computed<Record<string, string>>(() => {
+  const out: Record<string, string> = {};
+  const desc = form.description?.trim() ?? '';
+  if (!desc) out.description = 'O campo Descrição é obrigatório.';
+  else if (desc.length < 3)
+    out.description = 'O campo Descrição deve possuir no mínimo 3 caracteres.';
+  else if (desc.length > 100)
+    out.description = 'O campo Descrição deve possuir no máximo 100 caracteres.';
+  if (!form.dueDate) out.dueDate = 'O campo Vencimento é obrigatório.';
+  if (!form.status) out.status = 'O campo Situação é obrigatório.';
+  if (!hasDetail.value) {
+    if (!form.currency_id) out.currency_id = 'O campo Moeda é obrigatório.';
+    if (!form.amount || form.amount <= 0) out.amount = 'O campo Valor é obrigatório.';
+    if (!form.account_id) out.account_id = 'O campo Conta é obrigatório.';
+    if (!form.category_id) out.category_id = 'O campo Categoria é obrigatório.';
+    if (form.status === 'Pago' && (!form.amountPaid || form.amountPaid <= 0)) {
+      out.amountPaid = 'O campo Valor pago é obrigatório.';
+    }
+  }
+  return out;
+});
+
+watch(
+  () => [props.visible, props.mode, props.expenseId] as const,
+  async ([visible, mode, id]) => {
+    if (!visible) return;
+    submitted.value = false;
+    selectedDetail.value = null;
+    loading.value = true;
+    try {
+      const [cur, acc, cat] = await Promise.all([
+        loadCurrencies(),
+        loadAccounts(),
+        loadCategories('Despesa'),
+      ]);
+      currencies.value = cur;
+      accounts.value = acc;
+      categories.value = cat;
+
+      if (mode === 'new') {
+        loaded.value = null;
+        form._id = undefined;
+        form.description = '';
+        form.dueDate = new Date();
+        form.scheduledPayment = false;
+        form.amount = null;
+        form.amountPaid = 0;
+        form.currency_id = getDefaultCurrencyId(cur);
+        form.account_id = '';
+        form.category_id = '';
+        form.status = 'Em aberto';
+        form.notes = '';
+        form.detail = [];
+      } else if (id) {
+        const expense = await getById(id);
+        loaded.value = expense;
+        form._id = mode === 'clone' ? undefined : expense._id;
+        form.description = expense.description ?? '';
+        const due = new Date(expense.dueDate);
+        if (mode === 'clone') {
+          form._id = undefined;
+          due.setMonth(due.getMonth() + 1);
+        }
+        form.dueDate = due;
+        form.scheduledPayment = !!expense.scheduledPayment;
+        form.amount = expense.amount;
+        form.amountPaid = expense.amountPaid ?? 0;
+        form.currency_id = expense.currency_id ?? '';
+        form.account_id = expense.account_id ?? '';
+        form.category_id = expense.category_id ?? '';
+        form.status = expense.status;
+        form.notes = expense.notes ?? '';
+        form.detail = (expense.detail ?? []).map((d, idx) => ({
+          ...d,
+          _key: `loaded-${idx}-${d._id ?? Math.random().toString(36).slice(2)}`,
+        }));
+        recomputeTotals();
+      }
+    } catch (err) {
+      emit('load-error', extractStatus(err));
+      emit('close');
+    } finally {
+      loading.value = false;
+    }
+  },
+  { immediate: true },
+);
+
+function onChangeStatus() {
+  if (form.status === 'Pago' && (!form.amountPaid || form.amountPaid === 0)) {
+    form.amountPaid = form.amount ?? 0;
+  }
+}
+
+function recomputeTotals() {
+  if (form.detail.length === 0) return;
+  form.account_id = '';
+  form.category_id = '';
+  form.currency_id = '';
+  let amount = 0;
+  let paid = 0;
+  form.detail.forEach((d) => {
+    amount += d.amount ?? 0;
+    if (d.status === 'Pago') paid += d.amount ?? 0;
+  });
+  form.amount = amount;
+  form.amountPaid = paid;
+  form.status = amount === paid ? 'Pago' : 'Em aberto';
+}
+
+function openDetail(mode: Mode, detail: ExpenseDetail | null) {
+  detailDialog.mode = mode;
+  detailDialog.detail = detail;
+  detailDialog.visible = true;
+}
+
+function closeDetailDialog() {
+  detailDialog.visible = false;
+}
+
+function onDetailSubmit(detail: ExpenseDetail, mode: Mode, originalKey: string | null) {
+  closeDetailDialog();
+  const newKey = `det-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const withKey: ExpenseDetail = { ...detail, _key: newKey };
+  if (mode === 'new' || mode === 'clone') {
+    form.detail.push(withKey);
+  } else if (originalKey) {
+    const idx = form.detail.findIndex((d) => d._key === originalKey);
+    if (idx >= 0) {
+      form.detail[idx] = { ...withKey, _key: originalKey };
+    }
+  }
+  form.detail.sort(compareDetails);
+  selectedDetail.value = null;
+  recomputeTotals();
+}
+
+function onDetailLoadError(status: number | string) {
+  emit('load-error', status);
+}
+
+function confirmDeleteDetail() {
+  if (!selectedDetail.value) return;
+  const key = selectedDetail.value._key;
+  confirm.require({
+    message: 'Confirma a exclusão do detalhe?',
+    header: 'Excluir detalhe',
+    rejectProps: { label: 'Cancelar', severity: 'secondary', text: true },
+    acceptProps: { label: 'Confirmar' },
+    accept: () => {
+      const idx = form.detail.findIndex((d) => d._key === key);
+      if (idx >= 0) form.detail.splice(idx, 1);
+      selectedDetail.value = null;
+      recomputeTotals();
+    },
+  });
+}
+
+function payDetail() {
+  if (!selectedDetail.value) return;
+  const key = selectedDetail.value._key;
+  const idx = form.detail.findIndex((d) => d._key === key);
+  if (idx >= 0) {
+    form.detail[idx] = { ...form.detail[idx], status: 'Pago' };
+  }
+  selectedDetail.value = null;
+  recomputeTotals();
+}
+
+function handleSubmit() {
+  if (Object.keys(errors.value).length > 0) {
+    submitted.value = true;
+    return;
+  }
+  recomputeTotals();
+  const due = form.dueDate as Date;
+  const dueIso = getDateDst(due).toISOString();
+
+  const detailPayload = form.detail.map((d) => ({
+    _id: d._id,
+    description: d.description,
+    amount: d.amount,
+    account_id: d.account_id,
+    category_id: d.category_id,
+    currency_id: d.currency_id,
+    status: d.status,
+  }));
+
+  let payload: ExpenseFormPayload;
+  if (props.mode === 'edit' && loaded.value) {
+    payload = {
+      ...loaded.value,
+      _id: loaded.value._id,
+      description: form.description.trim(),
+      dueDate: dueIso,
+      scheduledPayment: form.scheduledPayment,
+      amount: form.amount as number,
+      amountPaid: form.amountPaid ?? 0,
+      currency_id: form.currency_id || undefined,
+      account_id: form.account_id || undefined,
+      category_id: form.category_id || undefined,
+      status: form.status,
+      notes: form.notes ?? '',
+      detail: detailPayload,
+    };
+  } else {
+    payload = {
+      description: form.description.trim(),
+      dueDate: dueIso,
+      scheduledPayment: form.scheduledPayment,
+      amount: form.amount as number,
+      amountPaid: form.amountPaid ?? 0,
+      currency_id: form.currency_id || undefined,
+      account_id: form.account_id || undefined,
+      category_id: form.category_id || undefined,
+      status: form.status,
+      notes: form.notes ?? '',
+      detail: detailPayload,
+    };
+  }
+
+  // omit empty optional ids so the server schema's anyOf can match the detail branch
+  if (form.detail.length > 0) {
+    payload.account_id = undefined;
+    payload.category_id = undefined;
+    payload.currency_id = undefined;
+  }
+
+  emit('submit', payload, props.mode);
+}
+
+function handleClose() {
+  emit('close');
+}
+
+function extractStatus(err: unknown): number | string {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const r = (err as { response?: { status?: number } }).response;
+    return r?.status ?? 'erro';
+  }
+  return 'erro';
+}
+</script>

--- a/web/src/views/expenses/GeneratorFormDialog.vue
+++ b/web/src/views/expenses/GeneratorFormDialog.vue
@@ -1,0 +1,357 @@
+<template>
+  <Dialog
+    :visible="visible"
+    :header="'Gerar despesas'"
+    modal
+    :style="{ width: 'min(46rem, 95vw)' }"
+    :closable="false"
+    @update:visible="handleClose"
+  >
+    <div v-if="loading" class="flex justify-center py-8">
+      <ProgressSpinner style="width: 3rem; height: 3rem" />
+    </div>
+
+    <form v-else class="flex flex-col gap-4" @submit.prevent="handleSubmit">
+      <div class="grid grid-cols-12 gap-3">
+        <div class="col-span-12 sm:col-span-6 flex flex-col gap-1">
+          <label for="genInitialDate" class="text-sm font-medium">Data inicial</label>
+          <DatePicker
+            id="genInitialDate"
+            v-model="form.initialDate"
+            date-format="dd/mm/yy"
+            show-icon
+            :invalid="submitted && !!errors.initialDate"
+          />
+          <small v-if="submitted && errors.initialDate" class="text-red-600">{{
+            errors.initialDate
+          }}</small>
+        </div>
+        <div class="col-span-12 sm:col-span-6 flex flex-col gap-1">
+          <label for="genInstallments" class="text-sm font-medium">Número de parcelas</label>
+          <InputNumber
+            id="genInstallments"
+            v-model="form.installments"
+            :min="1"
+            :max="999"
+            :invalid="submitted && !!errors.installments"
+            :use-grouping="false"
+          />
+          <small v-if="submitted && errors.installments" class="text-red-600">{{
+            errors.installments
+          }}</small>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-12 gap-3">
+        <div class="col-span-12 sm:col-span-6 flex flex-col gap-1">
+          <label for="genDueDateType" class="text-sm font-medium">Vencimento</label>
+          <Select
+            id="genDueDateType"
+            v-model="form.dueDateType"
+            :options="dueDateTypeOptions"
+            option-label="label"
+            option-value="value"
+            :invalid="submitted && !!errors.dueDateType"
+            placeholder="Selecione"
+          />
+          <small v-if="submitted && errors.dueDateType" class="text-red-600">{{
+            errors.dueDateType
+          }}</small>
+        </div>
+        <div
+          v-if="form.dueDateType === 'DiaEspecifico'"
+          class="col-span-12 sm:col-span-3 flex flex-col gap-1"
+        >
+          <label for="genDueDateTypeDay" class="text-sm font-medium">Dia</label>
+          <InputNumber
+            id="genDueDateTypeDay"
+            v-model="form.dueDateTypeDay"
+            :min="1"
+            :max="31"
+            :invalid="submitted && !!errors.dueDateTypeDay"
+            :use-grouping="false"
+          />
+          <small v-if="submitted && errors.dueDateTypeDay" class="text-red-600">{{
+            errors.dueDateTypeDay
+          }}</small>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-12 gap-3">
+        <div class="col-span-4 sm:col-span-3 flex flex-col gap-1">
+          <label for="genCurrency" class="text-sm font-medium">Moeda</label>
+          <Select
+            id="genCurrency"
+            v-model="form.currency_id"
+            :options="currencies"
+            option-label="currencyCode"
+            option-value="_id"
+            :invalid="submitted && !!errors.currency_id"
+            placeholder="Moeda"
+          />
+          <small v-if="submitted && errors.currency_id" class="text-red-600">{{
+            errors.currency_id
+          }}</small>
+        </div>
+        <div class="col-span-8 sm:col-span-3 flex flex-col gap-1">
+          <label for="genAmount" class="text-sm font-medium">Valor</label>
+          <InputNumber
+            id="genAmount"
+            v-model="form.amount"
+            :min-fraction-digits="2"
+            :max-fraction-digits="2"
+            :invalid="submitted && !!errors.amount"
+            locale="pt-BR"
+            input-class="text-right"
+          />
+          <small v-if="submitted && errors.amount" class="text-red-600">{{
+            errors.amount
+          }}</small>
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <label for="genDescription" class="text-sm font-medium">Descrição</label>
+        <InputText
+          id="genDescription"
+          v-model="form.description"
+          maxlength="100"
+          :invalid="submitted && !!errors.description"
+        />
+        <small v-if="submitted && errors.description" class="text-red-600">{{
+          errors.description
+        }}</small>
+      </div>
+
+      <div class="flex items-center gap-2">
+        <Checkbox
+          v-model="form.descriptionInstallmentNumber"
+          inputId="genDescInstallment"
+          binary
+        />
+        <label for="genDescInstallment" class="text-sm">
+          Inserir o número da parcela na descrição
+        </label>
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <label for="genAccount" class="text-sm font-medium">Conta</label>
+        <Select
+          id="genAccount"
+          v-model="form.account_id"
+          :options="accounts"
+          option-label="name"
+          option-value="_id"
+          :invalid="submitted && !!errors.account_id"
+          placeholder="Selecione"
+        />
+        <small v-if="submitted && errors.account_id" class="text-red-600">{{
+          errors.account_id
+        }}</small>
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <label for="genCategory" class="text-sm font-medium">Categoria</label>
+        <Select
+          id="genCategory"
+          v-model="form.category_id"
+          :options="categories"
+          option-label="name"
+          option-value="_id"
+          :invalid="submitted && !!errors.category_id"
+          placeholder="Selecione"
+        />
+        <small v-if="submitted && errors.category_id" class="text-red-600">{{
+          errors.category_id
+        }}</small>
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <label for="genNotes" class="text-sm font-medium">Observações</label>
+        <Textarea id="genNotes" v-model="form.notes" rows="1" />
+      </div>
+    </form>
+
+    <template #footer>
+      <Button label="Cancelar" severity="secondary" text @click="handleClose" />
+      <Button label="Confirmar" :disabled="submitting || loading" @click="handleSubmit" />
+    </template>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref, watch } from 'vue';
+import Dialog from 'primevue/dialog';
+import InputText from 'primevue/inputtext';
+import InputNumber from 'primevue/inputnumber';
+import Select from 'primevue/select';
+import Button from 'primevue/button';
+import Checkbox from 'primevue/checkbox';
+import DatePicker from 'primevue/datepicker';
+import Textarea from 'primevue/textarea';
+import ProgressSpinner from 'primevue/progressspinner';
+import api from '../../lib/api';
+import {
+  useReferenceData,
+  type Account,
+  type CategoryRef,
+  type Currency,
+} from '../../composables/useReferenceData';
+import { getDateDst } from '../../lib/dateUtils';
+
+type DueDateType = 'PrimeiroDia' | 'UltimoDia' | 'DiaEspecifico';
+
+const props = defineProps<{
+  visible: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: 'submit'): void;
+  (e: 'close'): void;
+  (e: 'load-error', status: number | string): void;
+  (e: 'save-error', status: number | string): void;
+}>();
+
+const dueDateTypeOptions: { value: DueDateType; label: string }[] = [
+  { value: 'PrimeiroDia', label: 'Primeiro dia do mês' },
+  { value: 'UltimoDia', label: 'Último dia do mês' },
+  { value: 'DiaEspecifico', label: 'Dia específico' },
+];
+
+const { loadCurrencies, loadAccounts, loadCategories, getDefaultCurrencyId } = useReferenceData();
+
+const loading = ref(false);
+const submitting = ref(false);
+const submitted = ref(false);
+const currencies = ref<Currency[]>([]);
+const accounts = ref<Account[]>([]);
+const categories = ref<CategoryRef[]>([]);
+
+const form = reactive<{
+  initialDate: Date | null;
+  installments: number | null;
+  dueDateType: DueDateType;
+  dueDateTypeDay: number | null;
+  currency_id: string;
+  amount: number | null;
+  description: string;
+  descriptionInstallmentNumber: boolean;
+  account_id: string;
+  category_id: string;
+  notes: string;
+}>({
+  initialDate: new Date(),
+  installments: null,
+  dueDateType: 'PrimeiroDia',
+  dueDateTypeDay: null,
+  currency_id: '',
+  amount: null,
+  description: '',
+  descriptionInstallmentNumber: false,
+  account_id: '',
+  category_id: '',
+  notes: '',
+});
+
+const errors = computed<Record<string, string>>(() => {
+  const out: Record<string, string> = {};
+  if (!form.initialDate) out.initialDate = 'O campo Data inicial é obrigatório.';
+  if (!form.installments || form.installments <= 0)
+    out.installments = 'O campo Número de parcelas é obrigatório.';
+  if (!form.dueDateType) out.dueDateType = 'O campo Vencimento é obrigatório.';
+  if (form.dueDateType === 'DiaEspecifico' && (!form.dueDateTypeDay || form.dueDateTypeDay <= 0))
+    out.dueDateTypeDay = 'O campo Dia é obrigatório.';
+  if (!form.currency_id) out.currency_id = 'O campo Moeda é obrigatório.';
+  if (!form.amount || form.amount <= 0) out.amount = 'O campo Valor é obrigatório.';
+  const desc = form.description?.trim() ?? '';
+  if (!desc) out.description = 'O campo Descrição é obrigatório.';
+  else if (desc.length < 3)
+    out.description = 'O campo Descrição deve possuir no mínimo 3 caracteres.';
+  else if (desc.length > 100)
+    out.description = 'O campo Descrição deve possuir no máximo 100 caracteres.';
+  if (!form.account_id) out.account_id = 'O campo Conta é obrigatório.';
+  if (!form.category_id) out.category_id = 'O campo Categoria é obrigatório.';
+  return out;
+});
+
+watch(
+  () => props.visible,
+  async (visible) => {
+    if (!visible) return;
+    submitted.value = false;
+    loading.value = true;
+    try {
+      const [cur, acc, cat] = await Promise.all([
+        loadCurrencies(),
+        loadAccounts(),
+        loadCategories('Despesa'),
+      ]);
+      currencies.value = cur;
+      accounts.value = acc;
+      categories.value = cat;
+
+      form.initialDate = new Date();
+      form.installments = null;
+      form.dueDateType = 'PrimeiroDia';
+      form.dueDateTypeDay = null;
+      form.currency_id = getDefaultCurrencyId(cur);
+      form.amount = null;
+      form.description = '';
+      form.descriptionInstallmentNumber = false;
+      form.account_id = '';
+      form.category_id = '';
+      form.notes = '';
+    } catch (err) {
+      emit('load-error', extractStatus(err));
+      emit('close');
+    } finally {
+      loading.value = false;
+    }
+  },
+  { immediate: true },
+);
+
+async function handleSubmit() {
+  if (Object.keys(errors.value).length > 0) {
+    submitted.value = true;
+    return;
+  }
+  submitting.value = true;
+  try {
+    const payload: Record<string, unknown> = {
+      type: 'Despesa',
+      initialDate: getDateDst(form.initialDate as Date).toISOString(),
+      installments: form.installments,
+      dueDateType: form.dueDateType,
+      currency_id: form.currency_id,
+      amount: form.amount,
+      description: form.description.trim(),
+      descriptionInstallmentNumber: form.descriptionInstallmentNumber,
+      account_id: form.account_id,
+      category_id: form.category_id,
+      notes: form.notes ?? '',
+    };
+    if (form.dueDateType === 'DiaEspecifico') {
+      payload.dueDateTypeDay = form.dueDateTypeDay;
+    }
+    await api.post('/generator', payload);
+    emit('submit');
+  } catch (err) {
+    emit('save-error', extractStatus(err));
+  } finally {
+    submitting.value = false;
+  }
+}
+
+function handleClose() {
+  emit('close');
+}
+
+function extractStatus(err: unknown): number | string {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const r = (err as { response?: { status?: number } }).response;
+    return r?.status ?? 'erro';
+  }
+  return 'erro';
+}
+</script>


### PR DESCRIPTION
Adds Despesas under /app/expenses:
- ExpensesView with date-range filter, balance, toolbar (add/edit/ delete/clone/pay/generate), and DataTable with footer aggregations, scheduledPayment indicator, and late-payment row coloring
- ExpenseFormDialog with nested detail grid (auto-derives totals/ status when details exist) and ExpenseDetailFormDialog
- GeneratorFormDialog (Despesa) for the Gerar action
- useExpenses composable wrapping /api/expenses, the /api/expenses/:id?pay=true endpoint, and /api/totals/balance

Flips the AngularJS navbar Despesas entry to /app/expenses; legacy controllers, services, and templates are now orphaned and will be removed in a later cleanup pass.