### PR TITLE
Tweak Vue UI: condensed grid, theme switcher, mobile layout

### DIFF
--- a/web/src/components/AppNavbar.vue
+++ b/web/src/components/AppNavbar.vue
@@ -40,6 +40,16 @@
         />
         <span class="hidden sm:inline text-sm">{{ session.name }}</span>
         <Button
+          :icon="themeIcon"
+          severity="secondary"
+          text
+          rounded
+          aria-label="Tema"
+          v-tooltip.bottom="themeTooltip"
+          @click="toggleThemeMenu"
+        />
+        <Menu ref="themeMenu" :model="themeItems" :popup="true" />
+        <Button
           icon="pi pi-sign-out"
           severity="secondary"
           text
@@ -53,14 +63,16 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import Menubar from 'primevue/menubar';
 import Menu from 'primevue/menu';
 import Button from 'primevue/button';
 import type { MenuItem } from 'primevue/menuitem';
 import { getSession } from '../lib/session';
+import { useTheme, type ThemeMode } from '../composables/useTheme';
 
 const session = getSession();
+const { mode: themeMode, setMode } = useTheme();
 
 interface NavItem extends MenuItem {
   to?: string;
@@ -74,6 +86,30 @@ const items = ref<NavItem[]>([
   { label: 'Categorias', icon: 'pi pi-list', to: '/categories' },
   { label: 'Contas', icon: 'pi pi-building', url: '/accounts' },
 ]);
+
+const themeMeta: Record<ThemeMode, { label: string; icon: string }> = {
+  system: { label: 'Sistema', icon: 'pi pi-desktop' },
+  light: { label: 'Claro', icon: 'pi pi-sun' },
+  dark: { label: 'Escuro', icon: 'pi pi-moon' },
+};
+const THEME_ORDER: ThemeMode[] = ['system', 'light', 'dark'];
+
+const themeIcon = computed(() => themeMeta[themeMode.value].icon);
+const themeTooltip = computed(() => `Tema: ${themeMeta[themeMode.value].label}`);
+
+const themeMenu = ref();
+const themeItems = computed<MenuItem[]>(() =>
+  THEME_ORDER.map((value) => ({
+    label: themeMeta[value].label,
+    icon: themeMeta[value].icon,
+    class: themeMode.value === value ? 'p-menubar-item-active' : undefined,
+    command: () => setMode(value),
+  })),
+);
+
+function toggleThemeMenu(event: Event) {
+  themeMenu.value?.toggle(event);
+}
 
 const logoffMenu = ref();
 const logoffItems = ref<MenuItem[]>([

--- a/web/src/composables/useTheme.ts
+++ b/web/src/composables/useTheme.ts
@@ -1,0 +1,58 @@
+import { computed, ref, watch } from 'vue';
+
+export type ThemeMode = 'system' | 'light' | 'dark';
+
+const STORAGE_KEY = 'theme';
+const DARK_CLASS = 'dark';
+const VALID_MODES: ThemeMode[] = ['system', 'light', 'dark'];
+
+function readInitial(): ThemeMode {
+  if (typeof window === 'undefined') return 'system';
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (stored && (VALID_MODES as string[]).includes(stored)) {
+    return stored as ThemeMode;
+  }
+  return 'system';
+}
+
+function systemPrefersDark(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    window.matchMedia?.('(prefers-color-scheme: dark)').matches === true
+  );
+}
+
+const mode = ref<ThemeMode>(readInitial());
+const systemDark = ref<boolean>(systemPrefersDark());
+const isDark = computed(
+  () => mode.value === 'dark' || (mode.value === 'system' && systemDark.value),
+);
+
+function apply() {
+  if (typeof document === 'undefined') return;
+  document.documentElement.classList.toggle(DARK_CLASS, isDark.value);
+}
+
+apply();
+
+watch(isDark, apply);
+watch(mode, (value) => {
+  window.localStorage.setItem(STORAGE_KEY, value);
+});
+
+if (typeof window !== 'undefined' && window.matchMedia) {
+  const mql = window.matchMedia('(prefers-color-scheme: dark)');
+  mql.addEventListener?.('change', (event) => {
+    systemDark.value = event.matches;
+  });
+}
+
+export function useTheme() {
+  return {
+    mode,
+    isDark,
+    setMode(value: ThemeMode) {
+      mode.value = value;
+    },
+  };
+}

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -7,6 +7,7 @@ import Tooltip from 'primevue/tooltip';
 import App from './App.vue';
 import router from './router';
 import { primevueConfig } from './primevue';
+import './composables/useTheme';
 import './style.css';
 
 const app = createApp(App);

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -1,6 +1,8 @@
 @import 'tailwindcss';
 @import 'primeicons/primeicons.css';
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 html,
 body,
 #app {
@@ -11,6 +13,46 @@ body,
 }
 
 body {
-  background-color: var(--p-surface-50, #fafafa);
-  color: var(--p-surface-900, #18181b);
+  background-color: var(--p-content-background, #fafafa);
+  color: var(--p-text-color, #18181b);
+}
+
+.dark body {
+  background-color: var(--p-content-background, #0a0a0a);
+  color: var(--p-text-color, #fafafa);
+}
+
+/* Condensed data tables: tighter padding + slightly smaller font so more rows fit */
+.p-datatable.p-datatable-sm {
+  font-size: 0.8125rem;
+}
+.p-datatable.p-datatable-sm .p-datatable-thead > tr > th,
+.p-datatable.p-datatable-sm .p-datatable-tbody > tr > td,
+.p-datatable.p-datatable-sm .p-datatable-tfoot > tr > td {
+  padding: 0.4rem 0.5rem;
+}
+
+/* Right-aligned column headers (PrimeVue v4 puts flex on the inner content wrapper) */
+.p-datatable .p-datatable-thead > tr > th.header-end .p-datatable-column-header-content {
+  justify-content: flex-end;
+}
+
+/* Mobile navbar: hamburger button before the app title */
+@media (max-width: 960px) {
+  .p-menubar {
+    flex-wrap: nowrap;
+    align-items: center;
+  }
+  .p-menubar > .p-menubar-button {
+    order: 1;
+    margin-left: 0;
+    margin-right: 0.5rem;
+  }
+  .p-menubar > .p-menubar-start {
+    order: 2;
+  }
+  .p-menubar > .p-menubar-end {
+    order: 3;
+    margin-left: auto;
+  }
 }

--- a/web/src/views/ExpensesView.vue
+++ b/web/src/views/ExpensesView.vue
@@ -1,6 +1,12 @@
 <template>
   <div class="container mx-auto px-4 py-6">
-    <h1 class="text-xl font-semibold mb-4">Cadastro de despesas</h1>
+    <div class="flex items-center justify-between mb-4 gap-4">
+      <h1 class="text-xl font-semibold">Cadastro de despesas</h1>
+      <div class="flex items-baseline gap-2">
+        <span class="text-sm text-slate-500">Saldo:</span>
+        <span :class="['font-semibold', balanceClass]">{{ formatNumber(balance) }}</span>
+      </div>
+    </div>
 
     <Toolbar class="mb-4">
       <template #start>
@@ -101,7 +107,7 @@
       </template>
 
       <template #end>
-        <div class="flex flex-wrap items-center gap-2">
+        <div class="hidden md:flex flex-wrap items-center gap-2">
           <DatePicker
             v-model="dueDateBegin"
             date-format="dd/mm/yy"
@@ -115,12 +121,6 @@
             input-class="!w-32"
           />
           <Button label="Filtrar" size="small" severity="secondary" @click="fetchAll" />
-          <div class="flex flex-col items-end ml-4">
-            <span class="text-xs text-slate-500 leading-none">Saldo</span>
-            <span :class="['font-semibold leading-tight', balanceClass]">{{
-              formatNumber(balance)
-            }}</span>
-          </div>
         </div>
       </template>
     </Toolbar>
@@ -156,7 +156,7 @@
         header="Valor"
         sortable
         style="width: 9rem"
-        header-class="!justify-end"
+        header-class="header-end"
       >
         <template #body="{ data }">
           <span class="block text-right">{{ formatNumber(data.amount) }}</span>
@@ -173,7 +173,7 @@
         header="Valor pago"
         sortable
         style="width: 9rem"
-        header-class="!justify-end"
+        header-class="header-end"
       >
         <template #body="{ data }">
           <span class="block text-right">{{ formatNumber(data.amountPaid) }}</span>
@@ -182,7 +182,14 @@
           <span class="block text-right">{{ formatNumber(amountPaidTotal) }}</span>
         </template>
       </Column>
-      <Column header="Ag." style="width: 4rem" class="text-center">
+      <Column style="width: 4rem" class="text-center">
+        <template #header>
+          <i
+            class="pi pi-calendar text-lg"
+            aria-label="Agendado"
+            v-tooltip.bottom="'Agendado'"
+          />
+        </template>
         <template #body="{ data }">
           <i v-if="data.scheduledPayment" class="pi pi-check text-slate-600" />
         </template>

--- a/web/src/views/IncomesView.vue
+++ b/web/src/views/IncomesView.vue
@@ -1,6 +1,12 @@
 <template>
   <div class="container mx-auto px-4 py-6">
-    <h1 class="text-xl font-semibold mb-4">Cadastro de receitas</h1>
+    <div class="flex items-center justify-between mb-4 gap-4">
+      <h1 class="text-xl font-semibold">Cadastro de receitas</h1>
+      <div class="flex items-baseline gap-2">
+        <span class="text-sm text-slate-500">Saldo:</span>
+        <span :class="['font-semibold', balanceClass]">{{ formatNumber(balance) }}</span>
+      </div>
+    </div>
 
     <Toolbar class="mb-4">
       <template #start>
@@ -101,7 +107,7 @@
       </template>
 
       <template #end>
-        <div class="flex flex-wrap items-center gap-2">
+        <div class="hidden md:flex flex-wrap items-center gap-2">
           <DatePicker
             v-model="dueDateBegin"
             date-format="dd/mm/yy"
@@ -115,12 +121,6 @@
             input-class="!w-32"
           />
           <Button label="Filtrar" size="small" severity="secondary" @click="fetchAll" />
-          <div class="flex flex-col items-end ml-4">
-            <span class="text-xs text-slate-500 leading-none">Saldo</span>
-            <span :class="['font-semibold leading-tight', balanceClass]">{{
-              formatNumber(balance)
-            }}</span>
-          </div>
         </div>
       </template>
     </Toolbar>
@@ -156,7 +156,7 @@
         header="Valor"
         sortable
         style="width: 9rem"
-        header-class="!justify-end"
+        header-class="header-end"
       >
         <template #body="{ data }">
           <span class="block text-right">{{ formatNumber(data.amount) }}</span>
@@ -173,7 +173,7 @@
         header="Valor receb."
         sortable
         style="width: 9rem"
-        header-class="!justify-end"
+        header-class="header-end"
       >
         <template #body="{ data }">
           <span class="block text-right">{{ formatNumber(data.amountReceived) }}</span>


### PR DESCRIPTION
- Condense DataTable rows (smaller padding + 0.8125rem font) so more records fit per page across Categories/Incomes/Expenses
- Add three-state theme switcher (System/Light/Dark) in the navbar, defaulting to System and reacting live to OS preference changes
- On mobile (<768px), hide the date-range pickers + Filtrar button on Incomes/Expenses; the month-navigation buttons remain
- On mobile (<960px), reorder the Menubar so the hamburger button comes before the app title
- Move the Saldo total into the page title row, right-aligned
- Replace the "Ag." (Agendado) header on Expenses with a pi-calendar icon
- Right-align Valor / Valor pago / Valor receb. column headers (the previous !justify-end on the th had no effect because PrimeVue v4 flex-lays-out an inner .p-datatable-column-header-content wrapper)