### PR TITLE
Hide Conta/Categoria/valor-pago/valor-receb columns on mobile

### DIFF
--- a/web/src/views/ExpensesView.vue
+++ b/web/src/views/ExpensesView.vue
@@ -165,15 +165,31 @@
           <span class="block text-right">{{ formatNumber(amountTotal) }}</span>
         </template>
       </Column>
-      <Column field="_accountNames" header="Conta" sortable style="width: 12rem" />
-      <Column field="_categoryNames" header="Categoria" sortable style="width: 12rem" />
+      <Column
+        field="_accountNames"
+        header="Conta"
+        sortable
+        style="width: 12rem"
+        class="hidden md:table-cell"
+        header-class="hidden md:table-cell"
+      />
+      <Column
+        field="_categoryNames"
+        header="Categoria"
+        sortable
+        style="width: 12rem"
+        class="hidden md:table-cell"
+        header-class="hidden md:table-cell"
+      />
       <Column field="status" header="Situação" sortable style="width: 8rem" class="text-center" />
       <Column
         field="amountPaid"
         header="Valor pago"
         sortable
         style="width: 9rem"
-        header-class="header-end"
+        class="hidden md:table-cell"
+        header-class="header-end hidden md:table-cell"
+        footer-class="hidden md:table-cell"
       >
         <template #body="{ data }">
           <span class="block text-right">{{ formatNumber(data.amountPaid) }}</span>
@@ -182,7 +198,11 @@
           <span class="block text-right">{{ formatNumber(amountPaidTotal) }}</span>
         </template>
       </Column>
-      <Column style="width: 4rem" class="text-center">
+      <Column
+        style="width: 4rem"
+        class="text-center hidden md:table-cell"
+        header-class="hidden md:table-cell"
+      >
         <template #header>
           <i
             class="pi pi-calendar text-lg"

--- a/web/src/views/IncomesView.vue
+++ b/web/src/views/IncomesView.vue
@@ -165,15 +165,31 @@
           <span class="block text-right">{{ formatNumber(amountTotal) }}</span>
         </template>
       </Column>
-      <Column field="_accountNames" header="Conta" sortable style="width: 12rem" />
-      <Column field="_categoryNames" header="Categoria" sortable style="width: 12rem" />
+      <Column
+        field="_accountNames"
+        header="Conta"
+        sortable
+        style="width: 12rem"
+        class="hidden md:table-cell"
+        header-class="hidden md:table-cell"
+      />
+      <Column
+        field="_categoryNames"
+        header="Categoria"
+        sortable
+        style="width: 12rem"
+        class="hidden md:table-cell"
+        header-class="hidden md:table-cell"
+      />
       <Column field="status" header="Situação" sortable style="width: 8rem" class="text-center" />
       <Column
         field="amountReceived"
         header="Valor receb."
         sortable
         style="width: 9rem"
-        header-class="header-end"
+        class="hidden md:table-cell"
+        header-class="header-end hidden md:table-cell"
+        footer-class="hidden md:table-cell"
       >
         <template #body="{ data }">
           <span class="block text-right">{{ formatNumber(data.amountReceived) }}</span>


### PR DESCRIPTION
On Incomes and Expenses, below 768px only Vencimento, Descrição, Moeda, Valor and Situação remain visible. The hidden columns (and the Expenses calendar/scheduled column) come back at md+ via Tailwind's hidden / md:table-cell utilities applied to header, body and footer.