### PR TITLE
Migrate Accounts, Transfers, Loans to Vue 3 + PrimeVue (strangler pat…

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -117,13 +117,13 @@
 								Despesas</a></li>
 						<li><a href="/app/incomes"><i class="fa fa-plus-square fa-lg"></i>
 								Receitas</a></li>
-						<li><a href="" ng-click="changeRoute('/transfers')"><i class="fa fa-exchange fa-lg"></i>
+						<li><a href="/app/transfers"><i class="fa fa-exchange fa-lg"></i>
 								Transferências</a></li>
-						<li><a href="" ng-click="changeRoute('/loans')"><i class="fa fa-money fa-lg"></i>
+						<li><a href="/app/loans"><i class="fa fa-money fa-lg"></i>
 								Empréstimos</a></li>
 						<li><a href="/app/categories"><i class="fa fa-list-ol fa-lg"></i>
 								Categorias</a></li>
-						<li><a href="" ng-click="changeRoute('/accounts')"><i class="fa fa-university fa-lg"></i>
+						<li><a href="/app/accounts"><i class="fa fa-university fa-lg"></i>
 								Contas</a></li>
 					</ul>
 				</div>

--- a/web/src/components/AppNavbar.vue
+++ b/web/src/components/AppNavbar.vue
@@ -81,10 +81,10 @@ interface NavItem extends MenuItem {
 const items = ref<NavItem[]>([
   { label: 'Despesas', icon: 'pi pi-minus-circle', to: '/expenses' },
   { label: 'Receitas', icon: 'pi pi-plus-circle', to: '/incomes' },
-  { label: 'Transferências', icon: 'pi pi-arrows-h', url: '/transfers' },
-  { label: 'Empréstimos', icon: 'pi pi-dollar', url: '/loans' },
+  { label: 'Transferências', icon: 'pi pi-arrows-h', to: '/transfers' },
+  { label: 'Empréstimos', icon: 'pi pi-dollar', to: '/loans' },
   { label: 'Categorias', icon: 'pi pi-list', to: '/categories' },
-  { label: 'Contas', icon: 'pi pi-building', url: '/accounts' },
+  { label: 'Contas', icon: 'pi pi-building', to: '/accounts' },
 ]);
 
 const themeMeta: Record<ThemeMode, { label: string; icon: string }> = {

--- a/web/src/composables/useAccounts.ts
+++ b/web/src/composables/useAccounts.ts
@@ -1,0 +1,65 @@
+import { ref } from 'vue';
+import api from '../lib/api';
+
+export interface Account {
+  _id: string;
+  name: string;
+  initialBalance: number;
+  order: number;
+  enabled: boolean;
+  currency_id: string;
+  user_id?: string;
+  _currency?: { _id: string; currencyCode: string } | null;
+}
+
+export type NewAccount = Omit<Account, '_id' | 'user_id' | '_currency'>;
+
+export function useAccounts() {
+  const rows = ref<Account[]>([]);
+  const loading = ref(false);
+  const selected = ref<Account | null>(null);
+  const listDisabled = ref(false);
+
+  async function fetchAll() {
+    loading.value = true;
+    try {
+      const filter = listDisabled.value ? '' : 'enabled=true';
+      const { data } = await api.get<Account[]>(`/accounts?${filter}`);
+      rows.value = data;
+      selected.value = null;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function getById(id: string) {
+    const { data } = await api.get<Account>(`/accounts/${id}`);
+    return data;
+  }
+
+  async function create(account: NewAccount) {
+    await api.post('/accounts', account);
+  }
+
+  async function update(account: Account) {
+    await api.patch(`/accounts/${account._id}`, account);
+  }
+
+  async function toggleEnabled(id: string, enable: boolean) {
+    const account = await getById(id);
+    account.enabled = enable;
+    await update(account);
+  }
+
+  return {
+    rows,
+    loading,
+    selected,
+    listDisabled,
+    fetchAll,
+    getById,
+    create,
+    update,
+    toggleEnabled,
+  };
+}

--- a/web/src/composables/useLoans.ts
+++ b/web/src/composables/useLoans.ts
@@ -1,0 +1,80 @@
+import { ref } from 'vue';
+import api from '../lib/api';
+import type { Account, Currency } from './useReferenceData';
+
+export type LoanType = 'Tomado' | 'Concedido';
+export type LoanStatus = 'Em aberto' | 'Quitado';
+
+export interface Loan {
+  _id: string;
+  description: string;
+  transactionDate: string;
+  dueDate: string;
+  amount: number;
+  account_id: string;
+  currency_id: string;
+  type: LoanType;
+  status: LoanStatus;
+  notes?: string;
+  user_id?: string;
+  _account?: Account | null;
+  _currency?: Currency | null;
+}
+
+export type LoanFormPayload = Omit<Loan, '_id' | '_account' | '_currency'> & {
+  _id?: string | null;
+};
+
+export function useLoans() {
+  const rows = ref<Loan[]>([]);
+  const loading = ref(false);
+  const selected = ref<Loan | null>(null);
+  const listPaid = ref(false);
+
+  async function fetchAll() {
+    loading.value = true;
+    try {
+      const filter = listPaid.value ? '' : 'status=Em aberto';
+      const { data } = await api.get<Loan[]>(`/loans?${encodeURI(filter)}`);
+      rows.value = data;
+      selected.value = null;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function getById(id: string): Promise<Loan> {
+    const { data } = await api.get<Loan>(`/loans/${id}`);
+    return data;
+  }
+
+  async function create(loan: LoanFormPayload): Promise<void> {
+    await api.post('/loans', loan);
+  }
+
+  async function update(loan: LoanFormPayload): Promise<void> {
+    if (!loan._id) throw new Error('Loan id is required for update');
+    await api.patch(`/loans/${loan._id}`, loan);
+  }
+
+  async function remove(id: string): Promise<void> {
+    await api.delete(`/loans/${id}`);
+  }
+
+  async function pay(id: string): Promise<void> {
+    await api.patch(`/loans/${id}?pay=true`);
+  }
+
+  return {
+    rows,
+    loading,
+    selected,
+    listPaid,
+    fetchAll,
+    getById,
+    create,
+    update,
+    remove,
+    pay,
+  };
+}

--- a/web/src/composables/useReferenceData.ts
+++ b/web/src/composables/useReferenceData.ts
@@ -86,6 +86,16 @@ export function useReferenceData() {
     return list.find((c) => c.default === true)?._id ?? '';
   }
 
+  function invalidate(key: 'accounts' | 'currencies'): void {
+    if (key === 'accounts') {
+      accounts.value = null;
+      accountsPromise = null;
+    } else if (key === 'currencies') {
+      currencies.value = null;
+      currenciesPromise = null;
+    }
+  }
+
   return {
     currencies,
     accounts,
@@ -93,5 +103,6 @@ export function useReferenceData() {
     loadAccounts,
     loadCategories,
     getDefaultCurrencyId,
+    invalidate,
   };
 }

--- a/web/src/composables/useTransfers.ts
+++ b/web/src/composables/useTransfers.ts
@@ -1,0 +1,91 @@
+import { ref } from 'vue';
+import api from '../lib/api';
+import type { Account, Currency } from './useReferenceData';
+import type { BalanceResponse } from './useIncomes';
+
+export interface Transfer {
+  _id: string;
+  date: string;
+  amount: number;
+  accountOrigin_id: string;
+  accountTarget_id: string;
+  currency_id: string;
+  user_id?: string;
+  _accountOrigin?: Account | null;
+  _accountTarget?: Account | null;
+  _currency?: Currency | null;
+}
+
+export type TransferFormPayload = Omit<
+  Transfer,
+  '_id' | '_accountOrigin' | '_accountTarget' | '_currency'
+> & {
+  _id?: string | null;
+};
+
+export function useTransfers() {
+  const rows = ref<Transfer[]>([]);
+  const loading = ref(false);
+  const selected = ref<Transfer | null>(null);
+  const balance = ref<number>(0);
+
+  function buildDateFilter(begin: Date, end: Date): string {
+    const y1 = begin.getFullYear();
+    const m1 = begin.getMonth();
+    const d1 = begin.getDate();
+    const startDate = new Date(y1, m1, d1);
+
+    const y2 = end.getFullYear();
+    const m2 = end.getMonth();
+    const d2 = end.getDate();
+    const endDate = new Date(y2, m2, d2, 23, 59, 59, 999);
+
+    return `dateBegin=${startDate.toString()}&dateEnd=${endDate.toString()}`;
+  }
+
+  async function fetchAll(begin: Date, end: Date) {
+    loading.value = true;
+    try {
+      const filter = buildDateFilter(begin, end);
+      const [transfersResp, balanceResp] = await Promise.all([
+        api.get<Transfer[]>(`/transfers?${filter}`),
+        api.get<BalanceResponse>(`/totals/balance?${filter}`),
+      ]);
+      rows.value = transfersResp.data;
+      balance.value = balanceResp.data?.current?.all?.partialBalance ?? 0;
+      selected.value = null;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function getById(id: string): Promise<Transfer> {
+    const { data } = await api.get<Transfer>(`/transfers/${id}`);
+    return data;
+  }
+
+  async function create(transfer: TransferFormPayload): Promise<void> {
+    await api.post('/transfers', transfer);
+  }
+
+  async function update(transfer: TransferFormPayload): Promise<void> {
+    if (!transfer._id) throw new Error('Transfer id is required for update');
+    await api.patch(`/transfers/${transfer._id}`, transfer);
+  }
+
+  async function remove(id: string): Promise<void> {
+    await api.delete(`/transfers/${id}`);
+  }
+
+  return {
+    rows,
+    loading,
+    selected,
+    balance,
+    fetchAll,
+    getById,
+    create,
+    update,
+    remove,
+  };
+}

--- a/web/src/router.ts
+++ b/web/src/router.ts
@@ -2,6 +2,9 @@ import { createRouter, createWebHistory } from 'vue-router';
 import CategoriesView from './views/CategoriesView.vue';
 import IncomesView from './views/IncomesView.vue';
 import ExpensesView from './views/ExpensesView.vue';
+import AccountsView from './views/AccountsView.vue';
+import TransfersView from './views/TransfersView.vue';
+import LoansView from './views/LoansView.vue';
 
 const router = createRouter({
   history: createWebHistory('/app/'),
@@ -10,6 +13,9 @@ const router = createRouter({
     { path: '/categories', name: 'categories', component: CategoriesView },
     { path: '/incomes', name: 'incomes', component: IncomesView },
     { path: '/expenses', name: 'expenses', component: ExpensesView },
+    { path: '/accounts', name: 'accounts', component: AccountsView },
+    { path: '/transfers', name: 'transfers', component: TransfersView },
+    { path: '/loans', name: 'loans', component: LoansView },
   ],
 });
 

--- a/web/src/views/AccountsView.vue
+++ b/web/src/views/AccountsView.vue
@@ -1,0 +1,221 @@
+<template>
+  <div class="container mx-auto px-4 py-6">
+    <h1 class="text-xl font-semibold mb-4">Cadastro de contas</h1>
+
+    <Toolbar class="mb-4">
+      <template #start>
+        <div class="flex gap-2">
+          <Button
+            icon="pi pi-plus"
+            severity="primary"
+            size="small"
+            aria-label="Adicionar"
+            v-tooltip.bottom="'Adicionar'"
+            @click="openNew"
+          />
+          <Button
+            icon="pi pi-pencil"
+            severity="primary"
+            size="small"
+            aria-label="Editar"
+            :disabled="!selected"
+            v-tooltip.bottom="'Editar'"
+            @click="openEdit"
+          />
+          <Button
+            v-if="selected?.enabled === true"
+            icon="pi pi-times"
+            severity="primary"
+            size="small"
+            aria-label="Inativar"
+            v-tooltip.bottom="'Inativar'"
+            @click="confirmToggle(false)"
+          />
+          <Button
+            v-if="selected?.enabled === false"
+            icon="pi pi-check"
+            severity="primary"
+            size="small"
+            aria-label="Ativar"
+            v-tooltip.bottom="'Ativar'"
+            @click="confirmToggle(true)"
+          />
+        </div>
+      </template>
+
+      <template #end>
+        <label class="flex items-center gap-2 text-sm">
+          <Checkbox v-model="listDisabled" binary @change="fetchAll" />
+          Listar contas inativas?
+        </label>
+      </template>
+    </Toolbar>
+
+    <DataTable
+      v-model:selection="selected"
+      :value="rows"
+      :loading="loading"
+      data-key="_id"
+      selection-mode="single"
+      removable-sort
+      striped-rows
+      :paginator="rows.length > 25"
+      :rows="25"
+      class="p-datatable-sm"
+    >
+      <template #footer>{{ rows.length }} registros</template>
+      <Column field="name" header="Nome" sortable />
+      <Column
+        field="_currency.currencyCode"
+        header="Moeda"
+        sortable
+        style="width: 6rem"
+        class="text-center"
+      />
+      <Column
+        field="initialBalance"
+        header="Saldo inicial"
+        sortable
+        style="width: 10rem"
+        header-class="header-end"
+      >
+        <template #body="{ data }">
+          <span class="block text-right">{{ formatNumber(data.initialBalance) }}</span>
+        </template>
+      </Column>
+      <Column
+        field="order"
+        header="Ordem"
+        sortable
+        style="width: 6rem"
+        class="text-center hidden md:table-cell"
+        header-class="hidden md:table-cell"
+      />
+      <Column header="Ativa?" style="width: 6rem" class="text-center">
+        <template #body="{ data }">
+          <i
+            :class="data.enabled ? 'pi pi-check text-green-600' : 'pi pi-times text-red-600'"
+            :aria-label="data.enabled ? 'Ativa' : 'Inativa'"
+          />
+        </template>
+      </Column>
+      <template #empty>Nenhuma conta encontrada.</template>
+    </DataTable>
+
+    <AccountFormDialog
+      :visible="dialog.visible"
+      :mode="dialog.mode"
+      :account-id="dialog.accountId"
+      @submit="onDialogSubmit"
+      @close="closeDialog"
+      @load-error="onLoadError"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, reactive } from 'vue';
+import DataTable from 'primevue/datatable';
+import Column from 'primevue/column';
+import Button from 'primevue/button';
+import Toolbar from 'primevue/toolbar';
+import Checkbox from 'primevue/checkbox';
+import { useToast } from 'primevue/usetoast';
+import { useConfirm } from 'primevue/useconfirm';
+import { useAccounts, type Account, type NewAccount } from '../composables/useAccounts';
+import { useReferenceData } from '../composables/useReferenceData';
+import { formatNumber } from '../lib/dateUtils';
+import AccountFormDialog from './accounts/AccountFormDialog.vue';
+
+const toast = useToast();
+const confirm = useConfirm();
+
+const { rows, loading, selected, listDisabled, fetchAll, create, update, toggleEnabled } =
+  useAccounts();
+const { invalidate } = useReferenceData();
+
+const dialog = reactive<{ visible: boolean; mode: 'new' | 'edit'; accountId: string | null }>({
+  visible: false,
+  mode: 'new',
+  accountId: null,
+});
+
+onMounted(() => {
+  fetchAll().catch((err) => onLoadError(extractStatus(err)));
+});
+
+function openNew() {
+  dialog.mode = 'new';
+  dialog.accountId = null;
+  dialog.visible = true;
+}
+
+function openEdit() {
+  if (!selected.value) return;
+  dialog.mode = 'edit';
+  dialog.accountId = selected.value._id;
+  dialog.visible = true;
+}
+
+function closeDialog() {
+  dialog.visible = false;
+}
+
+async function onDialogSubmit(payload: Account | NewAccount, mode: 'new' | 'edit') {
+  closeDialog();
+  try {
+    if (mode === 'new') {
+      await create(payload as NewAccount);
+      toast.add({ severity: 'success', summary: 'Conta adicionada com sucesso!', life: 4000 });
+    } else {
+      await update(payload as Account);
+      toast.add({ severity: 'success', summary: 'Conta editada com sucesso!', life: 4000 });
+    }
+    invalidate('accounts');
+    await fetchAll();
+  } catch (err) {
+    onSaveError(extractStatus(err));
+  }
+}
+
+function confirmToggle(enable: boolean) {
+  if (!selected.value) return;
+  const id = selected.value._id;
+  confirm.require({
+    message: enable ? 'Confirma a ativação da conta?' : 'Confirma a inativação da conta?',
+    header: enable ? 'Ativar conta' : 'Inativar conta',
+    rejectProps: { label: 'Cancelar', severity: 'secondary', text: true },
+    acceptProps: { label: 'Confirmar' },
+    accept: async () => {
+      try {
+        await toggleEnabled(id, enable);
+        toast.add({
+          severity: 'success',
+          summary: enable ? 'Conta ativada com sucesso!' : 'Conta inativada com sucesso!',
+          life: 4000,
+        });
+        invalidate('accounts');
+        await fetchAll();
+      } catch (err) {
+        onSaveError(extractStatus(err));
+      }
+    },
+  });
+}
+
+function onLoadError(status: number | string) {
+  toast.add({ severity: 'error', summary: `Erro ao carregar os dados: ${status}`, life: 6000 });
+}
+
+function onSaveError(status: number | string) {
+  toast.add({ severity: 'error', summary: `Erro ao salvar os dados: ${status}`, life: 6000 });
+}
+
+function extractStatus(err: unknown): number | string {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const r = (err as { response?: { status?: number } }).response;
+    return r?.status ?? 'erro';
+  }
+  return 'erro';
+}
+</script>

--- a/web/src/views/LoansView.vue
+++ b/web/src/views/LoansView.vue
@@ -1,0 +1,272 @@
+<template>
+  <div class="container mx-auto px-4 py-6">
+    <h1 class="text-xl font-semibold mb-4">Cadastro de empréstimos</h1>
+
+    <Toolbar class="mb-4">
+      <template #start>
+        <div class="flex gap-2 flex-wrap">
+          <Button
+            icon="pi pi-plus"
+            severity="primary"
+            size="small"
+            aria-label="Adicionar"
+            v-tooltip.bottom="'Adicionar'"
+            @click="openLoan('new', null)"
+          />
+          <Button
+            icon="pi pi-pencil"
+            severity="primary"
+            size="small"
+            :disabled="!selected"
+            aria-label="Editar"
+            v-tooltip.bottom="'Editar'"
+            @click="openLoan('edit', selected?._id ?? null)"
+          />
+          <Button
+            icon="pi pi-trash"
+            severity="primary"
+            size="small"
+            :disabled="!selected"
+            aria-label="Excluir"
+            v-tooltip.bottom="'Excluir'"
+            @click="confirmDelete"
+          />
+          <Button
+            icon="pi pi-clone"
+            severity="primary"
+            size="small"
+            :disabled="!selected"
+            aria-label="Clonar"
+            v-tooltip.bottom="'Clonar'"
+            @click="openLoan('clone', selected?._id ?? null)"
+          />
+          <Button
+            icon="pi pi-dollar"
+            severity="primary"
+            size="small"
+            :disabled="!selected || selected.status !== 'Em aberto'"
+            aria-label="Quitar"
+            v-tooltip.bottom="'Quitar'"
+            @click="confirmPay"
+          />
+        </div>
+      </template>
+
+      <template #end>
+        <label class="flex items-center gap-2 text-sm">
+          <Checkbox v-model="listPaid" binary @change="fetchAll" />
+          Listar empréstimos quitados?
+        </label>
+      </template>
+    </Toolbar>
+
+    <DataTable
+      v-model:selection="selected"
+      :value="rows"
+      :loading="loading"
+      data-key="_id"
+      selection-mode="single"
+      removable-sort
+      striped-rows
+      :paginator="rows.length > 25"
+      :rows="25"
+      class="p-datatable-sm"
+    >
+      <Column field="description" header="Descrição" sortable>
+        <template #footer>{{ rows.length }} registros</template>
+      </Column>
+      <Column
+        field="transactionDate"
+        header="Data"
+        sortable
+        style="width: 9rem"
+        class="text-center"
+      >
+        <template #body="{ data }">{{ formatShortDate(data.transactionDate) }}</template>
+      </Column>
+      <Column
+        field="dueDate"
+        header="Vencimento"
+        sortable
+        style="width: 9rem"
+        class="text-center hidden md:table-cell"
+        header-class="hidden md:table-cell"
+      >
+        <template #body="{ data }">{{ formatShortDate(data.dueDate) }}</template>
+      </Column>
+      <Column
+        field="_currency.currencyCode"
+        header="Moeda"
+        sortable
+        style="width: 6rem"
+        class="text-center"
+      />
+      <Column
+        field="amount"
+        header="Valor"
+        sortable
+        style="width: 9rem"
+        header-class="header-end"
+      >
+        <template #body="{ data }">
+          <span class="block text-right">{{ formatNumber(data.amount) }}</span>
+        </template>
+        <template #footer>
+          <span class="block text-right">{{ formatNumber(amountTotal) }}</span>
+        </template>
+      </Column>
+      <Column
+        field="_account.name"
+        header="Conta"
+        sortable
+        class="hidden md:table-cell"
+        header-class="hidden md:table-cell"
+      />
+      <Column
+        field="type"
+        header="Tipo"
+        sortable
+        style="width: 8rem"
+        class="text-center hidden md:table-cell"
+        header-class="hidden md:table-cell"
+      />
+      <Column field="status" header="Situação" sortable style="width: 8rem" class="text-center" />
+      <template #empty>Nenhum empréstimo encontrado.</template>
+    </DataTable>
+
+    <LoanFormDialog
+      :visible="dialog.visible"
+      :mode="dialog.mode"
+      :loan-id="dialog.loanId"
+      @submit="onDialogSubmit"
+      @close="closeDialog"
+      @load-error="onLoadError"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, reactive } from 'vue';
+import DataTable from 'primevue/datatable';
+import Column from 'primevue/column';
+import Button from 'primevue/button';
+import Toolbar from 'primevue/toolbar';
+import Checkbox from 'primevue/checkbox';
+import { useToast } from 'primevue/usetoast';
+import { useConfirm } from 'primevue/useconfirm';
+import { useLoans, type LoanFormPayload } from '../composables/useLoans';
+import { formatNumber, formatShortDate } from '../lib/dateUtils';
+import LoanFormDialog from './loans/LoanFormDialog.vue';
+
+const toast = useToast();
+const confirm = useConfirm();
+
+const { rows, loading, selected, listPaid, fetchAll, create, update, remove, pay } = useLoans();
+
+const dialog = reactive<{
+  visible: boolean;
+  mode: 'new' | 'edit' | 'clone';
+  loanId: string | null;
+}>({
+  visible: false,
+  mode: 'new',
+  loanId: null,
+});
+
+const amountTotal = computed(() => rows.value.reduce((acc, r) => acc + (r.amount ?? 0), 0));
+
+onMounted(() => {
+  fetchAll().catch((err) => onLoadError(extractStatus(err)));
+});
+
+function openLoan(mode: 'new' | 'edit' | 'clone', id: string | null) {
+  if ((mode === 'edit' || mode === 'clone') && !id) return;
+  dialog.mode = mode;
+  dialog.loanId = id;
+  dialog.visible = true;
+}
+
+function closeDialog() {
+  dialog.visible = false;
+}
+
+async function onDialogSubmit(payload: LoanFormPayload, mode: 'new' | 'edit' | 'clone') {
+  closeDialog();
+  try {
+    if (mode === 'edit') {
+      await update(payload);
+      toast.add({ severity: 'success', summary: 'Empréstimo editado com sucesso!', life: 4000 });
+    } else {
+      await create(payload);
+      toast.add({ severity: 'success', summary: 'Empréstimo adicionado com sucesso!', life: 4000 });
+    }
+    await fetchAll();
+  } catch (err) {
+    onSaveError(extractStatus(err));
+  }
+}
+
+function confirmDelete() {
+  if (!selected.value) return;
+  const id = selected.value._id;
+  confirm.require({
+    message: 'Confirma a exclusão do empréstimo?',
+    header: 'Excluir empréstimo',
+    rejectProps: { label: 'Cancelar', severity: 'secondary', text: true },
+    acceptProps: { label: 'Confirmar' },
+    accept: async () => {
+      try {
+        await remove(id);
+        toast.add({
+          severity: 'success',
+          summary: 'Empréstimo excluído com sucesso!',
+          life: 4000,
+        });
+        await fetchAll();
+      } catch (err) {
+        onSaveError(extractStatus(err));
+      }
+    },
+  });
+}
+
+function confirmPay() {
+  if (!selected.value) return;
+  const id = selected.value._id;
+  confirm.require({
+    message: 'Confirma a quitação do empréstimo?',
+    header: 'Quitar empréstimo',
+    rejectProps: { label: 'Cancelar', severity: 'secondary', text: true },
+    acceptProps: { label: 'Confirmar' },
+    accept: async () => {
+      try {
+        await pay(id);
+        toast.add({
+          severity: 'success',
+          summary: 'Empréstimo quitado com sucesso!',
+          life: 4000,
+        });
+        await fetchAll();
+      } catch (err) {
+        onSaveError(extractStatus(err));
+      }
+    },
+  });
+}
+
+function onLoadError(status: number | string) {
+  toast.add({ severity: 'error', summary: `Erro ao carregar os dados: ${status}`, life: 6000 });
+}
+
+function onSaveError(status: number | string) {
+  toast.add({ severity: 'error', summary: `Erro ao salvar os dados: ${status}`, life: 6000 });
+}
+
+function extractStatus(err: unknown): number | string {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const r = (err as { response?: { status?: number } }).response;
+    return r?.status ?? 'erro';
+  }
+  return 'erro';
+}
+</script>

--- a/web/src/views/TransfersView.vue
+++ b/web/src/views/TransfersView.vue
@@ -1,0 +1,326 @@
+<template>
+  <div class="container mx-auto px-4 py-6">
+    <div class="flex items-center justify-between mb-4 gap-4">
+      <h1 class="text-xl font-semibold">Cadastro de transferências</h1>
+      <div class="flex items-baseline gap-2">
+        <span class="text-sm text-slate-500">Saldo:</span>
+        <span :class="['font-semibold', balanceClass]">{{ formatNumber(balance) }}</span>
+      </div>
+    </div>
+
+    <Toolbar class="mb-4">
+      <template #start>
+        <div class="flex gap-2 flex-wrap">
+          <Button
+            icon="pi pi-plus"
+            severity="primary"
+            size="small"
+            aria-label="Adicionar"
+            v-tooltip.bottom="'Adicionar'"
+            @click="openTransfer('new', null)"
+          />
+          <Button
+            icon="pi pi-pencil"
+            severity="primary"
+            size="small"
+            :disabled="!selected"
+            aria-label="Editar"
+            v-tooltip.bottom="'Editar'"
+            @click="openTransfer('edit', selected?._id ?? null)"
+          />
+          <Button
+            icon="pi pi-trash"
+            severity="primary"
+            size="small"
+            :disabled="!selected"
+            aria-label="Excluir"
+            v-tooltip.bottom="'Excluir'"
+            @click="confirmDelete"
+          />
+        </div>
+      </template>
+
+      <template #center>
+        <div class="flex flex-wrap items-center gap-2">
+          <Button
+            size="small"
+            severity="success"
+            v-tooltip.bottom="'Ir para o início do ano'"
+            label="<<"
+            @click="navigate('beginYear')"
+          />
+          <Button
+            size="small"
+            severity="success"
+            v-tooltip.bottom="'Ir para o mês anterior'"
+            label="-1 Mês"
+            @click="navigate('prev')"
+          />
+          <Button
+            size="small"
+            severity="success"
+            v-tooltip.bottom="'Ir para o mês atual'"
+            label="Atual"
+            @click="navigate('actual')"
+          />
+          <Button
+            size="small"
+            severity="success"
+            v-tooltip.bottom="'Ir para o próximo mês'"
+            label="+1 Mês"
+            @click="navigate('next')"
+          />
+          <Button
+            size="small"
+            severity="success"
+            v-tooltip.bottom="'Ir para o fim do ano'"
+            label=">>"
+            @click="navigate('endYear')"
+          />
+        </div>
+      </template>
+
+      <template #end>
+        <div class="hidden md:flex flex-wrap items-center gap-2">
+          <DatePicker
+            v-model="dateBegin"
+            date-format="dd/mm/yy"
+            show-icon
+            input-class="!w-32"
+          />
+          <DatePicker
+            v-model="dateEnd"
+            date-format="dd/mm/yy"
+            show-icon
+            input-class="!w-32"
+          />
+          <Button label="Filtrar" size="small" severity="secondary" @click="fetchAll" />
+        </div>
+      </template>
+    </Toolbar>
+
+    <DataTable
+      v-model:selection="selected"
+      :value="rows"
+      :loading="loading"
+      data-key="_id"
+      selection-mode="single"
+      removable-sort
+      striped-rows
+      :paginator="rows.length > 25"
+      :rows="25"
+      class="p-datatable-sm"
+    >
+      <Column field="date" header="Data" sortable style="width: 9rem" class="text-center">
+        <template #body="{ data }">{{ formatShortDate(data.date) }}</template>
+        <template #footer>{{ rows.length }} registros</template>
+      </Column>
+      <Column
+        field="_currency.currencyCode"
+        header="Moeda"
+        sortable
+        style="width: 6rem"
+        class="text-center"
+      />
+      <Column
+        field="amount"
+        header="Valor"
+        sortable
+        style="width: 9rem"
+        header-class="header-end"
+      >
+        <template #body="{ data }">
+          <span class="block text-right">{{ formatNumber(data.amount) }}</span>
+        </template>
+        <template #footer>
+          <span class="block text-right">{{ formatNumber(amountTotal) }}</span>
+        </template>
+      </Column>
+      <Column field="_accountOrigin.name" header="Conta Origem" sortable />
+      <Column
+        field="_accountTarget.name"
+        header="Conta Destino"
+        sortable
+        class="hidden md:table-cell"
+        header-class="hidden md:table-cell"
+      />
+      <template #empty>Nenhuma transferência encontrada.</template>
+    </DataTable>
+
+    <TransferFormDialog
+      :visible="dialog.visible"
+      :mode="dialog.mode"
+      :transfer-id="dialog.transferId"
+      @submit="onDialogSubmit"
+      @close="closeDialog"
+      @load-error="onLoadError"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref } from 'vue';
+import DataTable from 'primevue/datatable';
+import Column from 'primevue/column';
+import Button from 'primevue/button';
+import Toolbar from 'primevue/toolbar';
+import DatePicker from 'primevue/datepicker';
+import { useToast } from 'primevue/usetoast';
+import { useConfirm } from 'primevue/useconfirm';
+import {
+  useTransfers,
+  type TransferFormPayload,
+} from '../composables/useTransfers';
+import {
+  formatNumber,
+  formatShortDate,
+  getActualMonth,
+  getBeginOfYear,
+  getEndOfYear,
+  getNextMonth,
+  getPreviousMonth,
+} from '../lib/dateUtils';
+import TransferFormDialog from './transfers/TransferFormDialog.vue';
+
+const toast = useToast();
+const confirm = useConfirm();
+
+const { rows, loading, selected, balance, fetchAll: fetchTransfers, create, update, remove } =
+  useTransfers();
+
+const { begin: initialBegin, end: initialEnd } = getActualMonth();
+const dateBegin = ref<Date | null>(initialBegin);
+const dateEnd = ref<Date | null>(initialEnd);
+
+const dialog = reactive<{ visible: boolean; mode: 'new' | 'edit'; transferId: string | null }>({
+  visible: false,
+  mode: 'new',
+  transferId: null,
+});
+
+const amountTotal = computed(() => rows.value.reduce((acc, r) => acc + (r.amount ?? 0), 0));
+const balanceClass = computed(() => {
+  if (balance.value < 0) return 'text-red-600';
+  if (balance.value === 0) return 'text-slate-500';
+  return 'text-green-600';
+});
+
+onMounted(fetchAll);
+
+async function fetchAll() {
+  if (!dateBegin.value || !dateEnd.value) return;
+  try {
+    await fetchTransfers(dateBegin.value, dateEnd.value);
+  } catch (err) {
+    onLoadError(extractStatus(err));
+  }
+}
+
+function navigate(target: 'beginYear' | 'prev' | 'actual' | 'next' | 'endYear') {
+  const base = dateBegin.value ?? new Date();
+  let range;
+  switch (target) {
+    case 'beginYear':
+      range = getBeginOfYear(base);
+      break;
+    case 'prev':
+      range = getPreviousMonth(base);
+      break;
+    case 'actual':
+      range = getActualMonth();
+      break;
+    case 'next':
+      range = getNextMonth(base);
+      break;
+    case 'endYear':
+      range = getEndOfYear(base);
+      break;
+  }
+  dateBegin.value = range.begin;
+  dateEnd.value = range.end;
+  fetchAll();
+}
+
+function openTransfer(mode: 'new' | 'edit', id: string | null) {
+  if (mode === 'edit' && !id) return;
+  dialog.mode = mode;
+  dialog.transferId = id;
+  dialog.visible = true;
+}
+
+function closeDialog() {
+  dialog.visible = false;
+}
+
+async function onDialogSubmit(payload: TransferFormPayload, mode: 'new' | 'edit') {
+  closeDialog();
+  try {
+    if (mode === 'edit') {
+      await update(payload);
+      toast.add({
+        severity: 'success',
+        summary: 'Transferência editada com sucesso!',
+        life: 4000,
+      });
+    } else {
+      await create(payload);
+      toast.add({
+        severity: 'success',
+        summary: 'Transferência adicionada com sucesso!',
+        life: 4000,
+      });
+    }
+    await fetchAll();
+  } catch (err) {
+    onSaveError(extractStatus(err));
+  }
+}
+
+function confirmDelete() {
+  if (!selected.value) return;
+  const id = selected.value._id;
+  confirm.require({
+    message: 'Confirma a exclusão da transferência?',
+    header: 'Excluir transferência',
+    rejectProps: { label: 'Cancelar', severity: 'secondary', text: true },
+    acceptProps: { label: 'Confirmar' },
+    accept: async () => {
+      try {
+        await remove(id);
+        toast.add({
+          severity: 'success',
+          summary: 'Transferência excluída com sucesso!',
+          life: 4000,
+        });
+        await fetchAll();
+      } catch (err) {
+        onSaveError(extractStatus(err));
+      }
+    },
+  });
+}
+
+function onLoadError(status: number | string) {
+  toast.add({
+    severity: 'error',
+    summary: `Erro ao carregar os dados: ${status}`,
+    life: 6000,
+  });
+}
+
+function onSaveError(status: number | string) {
+  toast.add({
+    severity: 'error',
+    summary: `Erro ao salvar os dados: ${status}`,
+    life: 6000,
+  });
+}
+
+function extractStatus(err: unknown): number | string {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const r = (err as { response?: { status?: number } }).response;
+    return r?.status ?? 'erro';
+  }
+  return 'erro';
+}
+</script>

--- a/web/src/views/accounts/AccountFormDialog.vue
+++ b/web/src/views/accounts/AccountFormDialog.vue
@@ -1,0 +1,237 @@
+<template>
+  <Dialog
+    :visible="visible"
+    :header="title"
+    modal
+    :style="{ width: 'min(32rem, 92vw)' }"
+    :closable="false"
+    @update:visible="handleClose"
+  >
+    <div v-if="loading" class="flex justify-center py-8">
+      <ProgressSpinner style="width: 3rem; height: 3rem" />
+    </div>
+
+    <form v-else class="flex flex-col gap-4" @submit.prevent="handleSubmit">
+      <div class="flex flex-col gap-1">
+        <label for="accountName" class="text-sm font-medium">Nome</label>
+        <InputText
+          id="accountName"
+          v-model="form.name"
+          :invalid="submitted && !!errors.name"
+          autofocus
+        />
+        <small v-if="submitted && errors.name" class="text-red-600">{{ errors.name }}</small>
+      </div>
+
+      <div class="flex flex-col sm:flex-row gap-3">
+        <div class="flex flex-col gap-1 sm:w-32">
+          <label for="accountCurrency" class="text-sm font-medium">Moeda</label>
+          <Select
+            id="accountCurrency"
+            v-model="form.currency_id"
+            :options="currencies"
+            option-label="currencyCode"
+            option-value="_id"
+            :invalid="submitted && !!errors.currency_id"
+            placeholder="Selecione"
+          />
+          <small v-if="submitted && errors.currency_id" class="text-red-600">{{
+            errors.currency_id
+          }}</small>
+        </div>
+
+        <div class="flex flex-col gap-1 flex-1">
+          <label for="accountInitialBalance" class="text-sm font-medium">Saldo inicial</label>
+          <InputNumber
+            id="accountInitialBalance"
+            v-model="form.initialBalance"
+            :min-fraction-digits="2"
+            :max-fraction-digits="2"
+            locale="pt-BR"
+            :invalid="submitted && !!errors.initialBalance"
+            input-class="w-full"
+          />
+          <small v-if="submitted && errors.initialBalance" class="text-red-600">{{
+            errors.initialBalance
+          }}</small>
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-1 sm:w-32">
+        <label for="accountOrder" class="text-sm font-medium">Ordem</label>
+        <InputNumber
+          id="accountOrder"
+          v-model="form.order"
+          :min="1"
+          :max="999"
+          :use-grouping="false"
+          :invalid="submitted && !!errors.order"
+          input-class="w-full"
+        />
+        <small v-if="submitted && errors.order" class="text-red-600">{{ errors.order }}</small>
+      </div>
+
+      <div class="flex items-center gap-2">
+        <Checkbox v-model="form.enabled" inputId="accountEnabled" binary />
+        <label for="accountEnabled" class="text-sm">Conta ativa?</label>
+      </div>
+    </form>
+
+    <template #footer>
+      <Button label="Cancelar" severity="secondary" text @click="handleClose" />
+      <Button label="Confirmar" :disabled="loading" @click="handleSubmit" />
+    </template>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref, watch } from 'vue';
+import Dialog from 'primevue/dialog';
+import InputText from 'primevue/inputtext';
+import InputNumber from 'primevue/inputnumber';
+import Select from 'primevue/select';
+import Checkbox from 'primevue/checkbox';
+import Button from 'primevue/button';
+import ProgressSpinner from 'primevue/progressspinner';
+import type { Account, NewAccount } from '../../composables/useAccounts';
+import { useAccounts } from '../../composables/useAccounts';
+import { useReferenceData, type Currency } from '../../composables/useReferenceData';
+
+type Mode = 'new' | 'edit';
+
+const props = defineProps<{
+  visible: boolean;
+  mode: Mode;
+  accountId: string | null;
+}>();
+
+const emit = defineEmits<{
+  (e: 'submit', value: Account | NewAccount, mode: Mode): void;
+  (e: 'close'): void;
+  (e: 'load-error', status: number | string): void;
+}>();
+
+const { getById } = useAccounts();
+const { loadCurrencies, getDefaultCurrencyId } = useReferenceData();
+
+const currencies = ref<Currency[]>([]);
+const loaded = ref<Account | null>(null);
+const loading = ref(false);
+const submitted = ref(false);
+
+const form = reactive<{
+  _id?: string;
+  name: string;
+  currency_id: string;
+  initialBalance: number | null;
+  order: number | null;
+  enabled: boolean;
+}>({
+  _id: undefined,
+  name: '',
+  currency_id: '',
+  initialBalance: 0,
+  order: null,
+  enabled: true,
+});
+
+const title = computed(() => (props.mode === 'new' ? 'Adicionar conta' : 'Editar conta'));
+
+const errors = computed<Record<string, string>>(() => {
+  const out: Record<string, string> = {};
+  const name = form.name?.trim() ?? '';
+  if (!name) out.name = 'O campo Nome é obrigatório.';
+  else if (name.length < 3) out.name = 'O campo Nome deve possuir no mínimo 3 caracteres.';
+  else if (name.length > 100) out.name = 'O campo Nome deve possuir no máximo 100 caracteres.';
+  if (!form.currency_id) out.currency_id = 'O campo Moeda é obrigatório.';
+  if (form.initialBalance == null || isNaN(form.initialBalance))
+    out.initialBalance = 'O campo Saldo inicial é obrigatório.';
+  if (form.order == null || isNaN(form.order) || form.order < 1 || form.order > 999)
+    out.order = 'O campo Ordem é obrigatório.';
+  return out;
+});
+
+onMounted(async () => {
+  try {
+    currencies.value = await loadCurrencies();
+  } catch (err: unknown) {
+    emit('load-error', extractStatus(err));
+  }
+});
+
+watch(
+  () => [props.visible, props.mode, props.accountId] as const,
+  async ([visible, mode, id]) => {
+    if (!visible) return;
+    submitted.value = false;
+    if (mode === 'new') {
+      loaded.value = null;
+      form._id = undefined;
+      form.name = '';
+      form.initialBalance = 0;
+      form.order = null;
+      form.enabled = true;
+      try {
+        if (currencies.value.length === 0) currencies.value = await loadCurrencies();
+        form.currency_id = getDefaultCurrencyId(currencies.value);
+      } catch (err: unknown) {
+        emit('load-error', extractStatus(err));
+        emit('close');
+      }
+      loading.value = false;
+      return;
+    }
+    if (id) {
+      loading.value = true;
+      try {
+        if (currencies.value.length === 0) currencies.value = await loadCurrencies();
+        const account = await getById(id);
+        loaded.value = account;
+        form._id = account._id;
+        form.name = account.name;
+        form.currency_id = account.currency_id;
+        form.initialBalance = account.initialBalance;
+        form.order = account.order;
+        form.enabled = account.enabled;
+      } catch (err: unknown) {
+        emit('load-error', extractStatus(err));
+        emit('close');
+      } finally {
+        loading.value = false;
+      }
+    }
+  },
+  { immediate: true },
+);
+
+function handleSubmit() {
+  if (Object.keys(errors.value).length > 0) {
+    submitted.value = true;
+    return;
+  }
+  const overrides = {
+    name: form.name.trim(),
+    currency_id: form.currency_id,
+    initialBalance: form.initialBalance as number,
+    order: form.order as number,
+    enabled: form.enabled,
+  };
+  const payload =
+    props.mode === 'edit' && loaded.value
+      ? { ...loaded.value, ...overrides }
+      : (overrides as NewAccount);
+  emit('submit', payload, props.mode);
+}
+
+function handleClose() {
+  emit('close');
+}
+
+function extractStatus(err: unknown): number | string {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const r = (err as { response?: { status?: number } }).response;
+    return r?.status ?? 'erro';
+  }
+  return 'erro';
+}
+</script>

--- a/web/src/views/loans/LoanFormDialog.vue
+++ b/web/src/views/loans/LoanFormDialog.vue
@@ -1,0 +1,351 @@
+<template>
+  <Dialog
+    :visible="visible"
+    :header="title"
+    modal
+    :style="{ width: 'min(40rem, 92vw)' }"
+    :closable="false"
+    @update:visible="handleClose"
+  >
+    <div v-if="loading" class="flex justify-center py-8">
+      <ProgressSpinner style="width: 3rem; height: 3rem" />
+    </div>
+
+    <form v-else class="flex flex-col gap-4" @submit.prevent="handleSubmit">
+      <div class="flex flex-col gap-1">
+        <label for="loanDescription" class="text-sm font-medium">Descrição</label>
+        <InputText
+          id="loanDescription"
+          v-model="form.description"
+          :invalid="submitted && !!errors.description"
+          autofocus
+        />
+        <small v-if="submitted && errors.description" class="text-red-600">{{
+          errors.description
+        }}</small>
+      </div>
+
+      <div class="flex flex-col sm:flex-row gap-3">
+        <div class="flex flex-col gap-1 flex-1">
+          <label for="loanTransactionDate" class="text-sm font-medium">Data de lançamento</label>
+          <DatePicker
+            id="loanTransactionDate"
+            v-model="form.transactionDate"
+            date-format="dd/mm/yy"
+            show-icon
+            :invalid="submitted && !!errors.transactionDate"
+          />
+          <small v-if="submitted && errors.transactionDate" class="text-red-600">{{
+            errors.transactionDate
+          }}</small>
+        </div>
+
+        <div class="flex flex-col gap-1 flex-1">
+          <label for="loanDueDate" class="text-sm font-medium">Data de vencimento</label>
+          <DatePicker
+            id="loanDueDate"
+            v-model="form.dueDate"
+            date-format="dd/mm/yy"
+            show-icon
+            :min-date="form.transactionDate ?? undefined"
+            :invalid="submitted && !!errors.dueDate"
+          />
+          <small v-if="submitted && errors.dueDate" class="text-red-600">{{ errors.dueDate }}</small>
+        </div>
+      </div>
+
+      <div class="flex flex-col sm:flex-row gap-3">
+        <div class="flex flex-col gap-1 sm:w-32">
+          <label for="loanCurrency" class="text-sm font-medium">Moeda</label>
+          <Select
+            id="loanCurrency"
+            v-model="form.currency_id"
+            :options="currencies"
+            option-label="currencyCode"
+            option-value="_id"
+            :invalid="submitted && !!errors.currency_id"
+            placeholder="Selecione"
+          />
+          <small v-if="submitted && errors.currency_id" class="text-red-600">{{
+            errors.currency_id
+          }}</small>
+        </div>
+
+        <div class="flex flex-col gap-1 flex-1">
+          <label for="loanAmount" class="text-sm font-medium">Valor</label>
+          <InputNumber
+            id="loanAmount"
+            v-model="form.amount"
+            :min-fraction-digits="2"
+            :max-fraction-digits="2"
+            locale="pt-BR"
+            :invalid="submitted && !!errors.amount"
+            input-class="w-full"
+          />
+          <small v-if="submitted && errors.amount" class="text-red-600">{{ errors.amount }}</small>
+        </div>
+      </div>
+
+      <div class="flex flex-col sm:flex-row gap-3">
+        <div class="flex flex-col gap-1 flex-1">
+          <label for="loanType" class="text-sm font-medium">Tipo de empréstimo</label>
+          <Select
+            id="loanType"
+            v-model="form.type"
+            :options="loanTypes"
+            :invalid="submitted && !!errors.type"
+            placeholder="Selecione"
+          />
+          <small v-if="submitted && errors.type" class="text-red-600">{{ errors.type }}</small>
+        </div>
+
+        <div class="flex flex-col gap-1 flex-1">
+          <label for="loanStatus" class="text-sm font-medium">Situação</label>
+          <Select
+            id="loanStatus"
+            v-model="form.status"
+            :options="loanStatuses"
+            :invalid="submitted && !!errors.status"
+            placeholder="Selecione"
+          />
+          <small v-if="submitted && errors.status" class="text-red-600">{{ errors.status }}</small>
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <label for="loanAccount" class="text-sm font-medium">Conta</label>
+        <Select
+          id="loanAccount"
+          v-model="form.account_id"
+          :options="accounts"
+          option-label="name"
+          option-value="_id"
+          :invalid="submitted && !!errors.account_id"
+          placeholder="Selecione"
+        />
+        <small v-if="submitted && errors.account_id" class="text-red-600">{{
+          errors.account_id
+        }}</small>
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <label for="loanNotes" class="text-sm font-medium">Observações</label>
+        <Textarea id="loanNotes" v-model="form.notes" rows="3" auto-resize />
+      </div>
+    </form>
+
+    <template #footer>
+      <Button label="Cancelar" severity="secondary" text @click="handleClose" />
+      <Button label="Confirmar" :disabled="loading" @click="handleSubmit" />
+    </template>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref, watch } from 'vue';
+import Dialog from 'primevue/dialog';
+import DatePicker from 'primevue/datepicker';
+import InputText from 'primevue/inputtext';
+import InputNumber from 'primevue/inputnumber';
+import Select from 'primevue/select';
+import Textarea from 'primevue/textarea';
+import Button from 'primevue/button';
+import ProgressSpinner from 'primevue/progressspinner';
+import type {
+  Loan,
+  LoanFormPayload,
+  LoanStatus,
+  LoanType,
+} from '../../composables/useLoans';
+import { useLoans } from '../../composables/useLoans';
+import { useReferenceData, type Account, type Currency } from '../../composables/useReferenceData';
+import { getDateDst } from '../../lib/dateUtils';
+
+type Mode = 'new' | 'edit' | 'clone';
+
+const props = defineProps<{
+  visible: boolean;
+  mode: Mode;
+  loanId: string | null;
+}>();
+
+const emit = defineEmits<{
+  (e: 'submit', value: LoanFormPayload, mode: Mode): void;
+  (e: 'close'): void;
+  (e: 'load-error', status: number | string): void;
+}>();
+
+const loanTypes: LoanType[] = ['Tomado', 'Concedido'];
+const loanStatuses: LoanStatus[] = ['Em aberto', 'Quitado'];
+
+const { getById } = useLoans();
+const { loadCurrencies, loadAccounts, getDefaultCurrencyId } = useReferenceData();
+
+const currencies = ref<Currency[]>([]);
+const accounts = ref<Account[]>([]);
+const loaded = ref<Loan | null>(null);
+const loading = ref(false);
+const submitted = ref(false);
+
+const form = reactive<{
+  _id?: string;
+  description: string;
+  transactionDate: Date | null;
+  dueDate: Date | null;
+  amount: number | null;
+  currency_id: string;
+  account_id: string;
+  type: LoanType | null;
+  status: LoanStatus | null;
+  notes: string;
+}>({
+  _id: undefined,
+  description: '',
+  transactionDate: null,
+  dueDate: null,
+  amount: null,
+  currency_id: '',
+  account_id: '',
+  type: null,
+  status: 'Em aberto',
+  notes: '',
+});
+
+const title = computed(() => {
+  if (props.mode === 'new') return 'Adicionar empréstimo';
+  if (props.mode === 'clone') return 'Clonar empréstimo';
+  return 'Editar empréstimo';
+});
+
+const errors = computed<Record<string, string>>(() => {
+  const out: Record<string, string> = {};
+  const description = form.description?.trim() ?? '';
+  if (!description) out.description = 'O campo Descrição é obrigatório.';
+  else if (description.length < 3)
+    out.description = 'O campo Descrição deve possuir no mínimo 3 caracteres.';
+  else if (description.length > 100)
+    out.description = 'O campo Descrição deve possuir no máximo 100 caracteres.';
+
+  if (!form.transactionDate || isNaN(form.transactionDate.getTime()))
+    out.transactionDate = 'O campo Data de lançamento é obrigatório.';
+  if (!form.dueDate || isNaN(form.dueDate.getTime())) {
+    out.dueDate = 'O campo Data de vencimento é obrigatório.';
+  } else if (form.transactionDate && !isNaN(form.transactionDate.getTime())) {
+    const tx = stripTime(form.transactionDate);
+    const due = stripTime(form.dueDate);
+    if (due < tx) out.dueDate = 'Não pode ser menor do que a Data de lançamento.';
+  }
+
+  if (form.amount == null || isNaN(form.amount) || form.amount <= 0)
+    out.amount = 'O campo Valor é obrigatório.';
+  if (!form.currency_id) out.currency_id = 'O campo Moeda é obrigatório.';
+  if (!form.type) out.type = 'O campo Tipo de empréstimo é obrigatório.';
+  if (!form.status) out.status = 'O campo Situação é obrigatório.';
+  if (!form.account_id) out.account_id = 'O campo Conta é obrigatório.';
+  return out;
+});
+
+onMounted(async () => {
+  try {
+    [currencies.value, accounts.value] = await Promise.all([loadCurrencies(), loadAccounts()]);
+  } catch (err: unknown) {
+    emit('load-error', extractStatus(err));
+  }
+});
+
+watch(
+  () => [props.visible, props.mode, props.loanId] as const,
+  async ([visible, mode, id]) => {
+    if (!visible) return;
+    submitted.value = false;
+    if (mode === 'new') {
+      loaded.value = null;
+      form._id = undefined;
+      form.description = '';
+      form.transactionDate = new Date();
+      form.dueDate = new Date();
+      form.amount = null;
+      form.account_id = '';
+      form.type = null;
+      form.status = 'Em aberto';
+      form.notes = '';
+      try {
+        if (currencies.value.length === 0) currencies.value = await loadCurrencies();
+        if (accounts.value.length === 0) accounts.value = await loadAccounts();
+        form.currency_id = getDefaultCurrencyId(currencies.value);
+      } catch (err: unknown) {
+        emit('load-error', extractStatus(err));
+        emit('close');
+      }
+      loading.value = false;
+      return;
+    }
+    if (id) {
+      loading.value = true;
+      try {
+        if (currencies.value.length === 0) currencies.value = await loadCurrencies();
+        if (accounts.value.length === 0) accounts.value = await loadAccounts();
+        const loan = await getById(id);
+        loaded.value = loan;
+        form._id = mode === 'clone' ? undefined : loan._id;
+        form.description = mode === 'clone' ? `${loan.description} - Cópia` : loan.description;
+        form.transactionDate = new Date(loan.transactionDate);
+        form.dueDate = new Date(loan.dueDate);
+        form.amount = loan.amount;
+        form.currency_id = loan.currency_id;
+        form.account_id = loan.account_id;
+        form.type = loan.type;
+        form.status = loan.status;
+        form.notes = loan.notes ?? '';
+      } catch (err: unknown) {
+        emit('load-error', extractStatus(err));
+        emit('close');
+      } finally {
+        loading.value = false;
+      }
+    }
+  },
+  { immediate: true },
+);
+
+function handleSubmit() {
+  if (Object.keys(errors.value).length > 0) {
+    submitted.value = true;
+    return;
+  }
+  const overrides = {
+    description: form.description.trim(),
+    transactionDate: getDateDst(form.transactionDate as Date).toISOString(),
+    dueDate: getDateDst(form.dueDate as Date).toISOString(),
+    amount: form.amount as number,
+    currency_id: form.currency_id,
+    account_id: form.account_id,
+    type: form.type as LoanType,
+    status: form.status as LoanStatus,
+    notes: form.notes ?? '',
+  };
+  let payload: LoanFormPayload;
+  if (props.mode === 'edit' && loaded.value) {
+    payload = { ...loaded.value, ...overrides } as LoanFormPayload;
+  } else {
+    payload = overrides as LoanFormPayload;
+  }
+  emit('submit', payload, props.mode);
+}
+
+function handleClose() {
+  emit('close');
+}
+
+function stripTime(d: Date): number {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+}
+
+function extractStatus(err: unknown): number | string {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const r = (err as { response?: { status?: number } }).response;
+    return r?.status ?? 'erro';
+  }
+  return 'erro';
+}
+</script>

--- a/web/src/views/transfers/TransferFormDialog.vue
+++ b/web/src/views/transfers/TransferFormDialog.vue
@@ -1,0 +1,259 @@
+<template>
+  <Dialog
+    :visible="visible"
+    :header="title"
+    modal
+    :style="{ width: 'min(36rem, 92vw)' }"
+    :closable="false"
+    @update:visible="handleClose"
+  >
+    <div v-if="loading" class="flex justify-center py-8">
+      <ProgressSpinner style="width: 3rem; height: 3rem" />
+    </div>
+
+    <form v-else class="flex flex-col gap-4" @submit.prevent="handleSubmit">
+      <div class="flex flex-col gap-1 sm:w-48">
+        <label for="transferDate" class="text-sm font-medium">Data</label>
+        <DatePicker
+          id="transferDate"
+          v-model="form.date"
+          date-format="dd/mm/yy"
+          show-icon
+          :invalid="submitted && !!errors.date"
+        />
+        <small v-if="submitted && errors.date" class="text-red-600">{{ errors.date }}</small>
+      </div>
+
+      <div class="flex flex-col sm:flex-row gap-3">
+        <div class="flex flex-col gap-1 sm:w-32">
+          <label for="transferCurrency" class="text-sm font-medium">Moeda</label>
+          <Select
+            id="transferCurrency"
+            v-model="form.currency_id"
+            :options="currencies"
+            option-label="currencyCode"
+            option-value="_id"
+            :invalid="submitted && !!errors.currency_id"
+            placeholder="Selecione"
+          />
+          <small v-if="submitted && errors.currency_id" class="text-red-600">{{
+            errors.currency_id
+          }}</small>
+        </div>
+
+        <div class="flex flex-col gap-1 flex-1">
+          <label for="transferAmount" class="text-sm font-medium">Valor</label>
+          <InputNumber
+            id="transferAmount"
+            v-model="form.amount"
+            :min-fraction-digits="2"
+            :max-fraction-digits="2"
+            locale="pt-BR"
+            :invalid="submitted && !!errors.amount"
+            input-class="w-full"
+          />
+          <small v-if="submitted && errors.amount" class="text-red-600">{{ errors.amount }}</small>
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <label for="transferAccountOrigin" class="text-sm font-medium">Conta Origem</label>
+        <Select
+          id="transferAccountOrigin"
+          v-model="form.accountOrigin_id"
+          :options="accounts"
+          option-label="name"
+          option-value="_id"
+          :invalid="submitted && !!errors.accountOrigin_id"
+          placeholder="Selecione"
+        />
+        <small v-if="submitted && errors.accountOrigin_id" class="text-red-600">{{
+          errors.accountOrigin_id
+        }}</small>
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <label for="transferAccountTarget" class="text-sm font-medium">Conta Destino</label>
+        <Select
+          id="transferAccountTarget"
+          v-model="form.accountTarget_id"
+          :options="accounts"
+          option-label="name"
+          option-value="_id"
+          :invalid="submitted && !!errors.accountTarget_id"
+          placeholder="Selecione"
+        />
+        <small v-if="submitted && errors.accountTarget_id" class="text-red-600">{{
+          errors.accountTarget_id
+        }}</small>
+      </div>
+    </form>
+
+    <template #footer>
+      <Button label="Cancelar" severity="secondary" text @click="handleClose" />
+      <Button label="Confirmar" :disabled="loading" @click="handleSubmit" />
+    </template>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref, watch } from 'vue';
+import Dialog from 'primevue/dialog';
+import DatePicker from 'primevue/datepicker';
+import InputNumber from 'primevue/inputnumber';
+import Select from 'primevue/select';
+import Button from 'primevue/button';
+import ProgressSpinner from 'primevue/progressspinner';
+import type { Transfer, TransferFormPayload } from '../../composables/useTransfers';
+import { useTransfers } from '../../composables/useTransfers';
+import { useReferenceData, type Account, type Currency } from '../../composables/useReferenceData';
+import { getDateDst } from '../../lib/dateUtils';
+
+type Mode = 'new' | 'edit';
+
+const props = defineProps<{
+  visible: boolean;
+  mode: Mode;
+  transferId: string | null;
+}>();
+
+const emit = defineEmits<{
+  (e: 'submit', value: TransferFormPayload, mode: Mode): void;
+  (e: 'close'): void;
+  (e: 'load-error', status: number | string): void;
+}>();
+
+const { getById } = useTransfers();
+const { loadCurrencies, loadAccounts, getDefaultCurrencyId } = useReferenceData();
+
+const currencies = ref<Currency[]>([]);
+const accounts = ref<Account[]>([]);
+const loaded = ref<Transfer | null>(null);
+const loading = ref(false);
+const submitted = ref(false);
+
+const form = reactive<{
+  _id?: string;
+  date: Date | null;
+  amount: number | null;
+  currency_id: string;
+  accountOrigin_id: string;
+  accountTarget_id: string;
+}>({
+  _id: undefined,
+  date: null,
+  amount: null,
+  currency_id: '',
+  accountOrigin_id: '',
+  accountTarget_id: '',
+});
+
+const title = computed(() =>
+  props.mode === 'new' ? 'Adicionar transferência' : 'Editar transferência',
+);
+
+const errors = computed<Record<string, string>>(() => {
+  const out: Record<string, string> = {};
+  if (!form.date || isNaN(form.date.getTime())) out.date = 'O campo Data é obrigatório.';
+  if (!form.currency_id) out.currency_id = 'O campo Moeda é obrigatório.';
+  if (form.amount == null || isNaN(form.amount) || form.amount <= 0)
+    out.amount = 'O campo Valor é obrigatório.';
+  if (!form.accountOrigin_id) {
+    out.accountOrigin_id = 'O campo Conta Origem é obrigatório.';
+  } else if (form.accountOrigin_id === form.accountTarget_id) {
+    out.accountOrigin_id = 'A Conta Origem deve ser diferente da Conta Destino.';
+  }
+  if (!form.accountTarget_id) {
+    out.accountTarget_id = 'O campo Conta Destino é obrigatório.';
+  } else if (form.accountTarget_id === form.accountOrigin_id) {
+    out.accountTarget_id = 'A Conta Destino deve ser diferente da Conta Origem.';
+  }
+  return out;
+});
+
+onMounted(async () => {
+  try {
+    [currencies.value, accounts.value] = await Promise.all([loadCurrencies(), loadAccounts()]);
+  } catch (err: unknown) {
+    emit('load-error', extractStatus(err));
+  }
+});
+
+watch(
+  () => [props.visible, props.mode, props.transferId] as const,
+  async ([visible, mode, id]) => {
+    if (!visible) return;
+    submitted.value = false;
+    if (mode === 'new') {
+      loaded.value = null;
+      form._id = undefined;
+      form.date = new Date();
+      form.amount = null;
+      form.accountOrigin_id = '';
+      form.accountTarget_id = '';
+      try {
+        if (currencies.value.length === 0) currencies.value = await loadCurrencies();
+        if (accounts.value.length === 0) accounts.value = await loadAccounts();
+        form.currency_id = getDefaultCurrencyId(currencies.value);
+      } catch (err: unknown) {
+        emit('load-error', extractStatus(err));
+        emit('close');
+      }
+      loading.value = false;
+      return;
+    }
+    if (id) {
+      loading.value = true;
+      try {
+        if (currencies.value.length === 0) currencies.value = await loadCurrencies();
+        if (accounts.value.length === 0) accounts.value = await loadAccounts();
+        const transfer = await getById(id);
+        loaded.value = transfer;
+        form._id = transfer._id;
+        form.date = new Date(transfer.date);
+        form.amount = transfer.amount;
+        form.currency_id = transfer.currency_id;
+        form.accountOrigin_id = transfer.accountOrigin_id;
+        form.accountTarget_id = transfer.accountTarget_id;
+      } catch (err: unknown) {
+        emit('load-error', extractStatus(err));
+        emit('close');
+      } finally {
+        loading.value = false;
+      }
+    }
+  },
+  { immediate: true },
+);
+
+function handleSubmit() {
+  if (Object.keys(errors.value).length > 0) {
+    submitted.value = true;
+    return;
+  }
+  const overrides = {
+    date: getDateDst(form.date as Date).toISOString(),
+    amount: form.amount as number,
+    currency_id: form.currency_id,
+    accountOrigin_id: form.accountOrigin_id,
+    accountTarget_id: form.accountTarget_id,
+  };
+  const payload: TransferFormPayload =
+    props.mode === 'edit' && loaded.value
+      ? ({ ...loaded.value, ...overrides } as TransferFormPayload)
+      : (overrides as TransferFormPayload);
+  emit('submit', payload, props.mode);
+}
+
+function handleClose() {
+  emit('close');
+}
+
+function extractStatus(err: unknown): number | string {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const r = (err as { response?: { status?: number } }).response;
+    return r?.status ?? 'erro';
+  }
+  return 'erro';
+}
+</script>


### PR DESCRIPTION
…tern)

Adds three more screens to the Vue strangler app, following the recipe documented for Categories/Incomes/Expenses:

- Accounts (/app/accounts) — list, add, edit, activate/inactivate. No DELETE, mirroring the server (returns 405). "Listar contas inativas?" toggle. Columns: Nome, Moeda, Saldo inicial, Ordem, Ativa?
- Transfers (/app/transfers) — list with date range, add/edit/delete, Saldo from /totals/balance, month navigation buttons, date pickers hidden below md. Form-side validation that origin != target mirrors the server schema check.
- Loans (/app/loans) — list, add/edit/delete/clone/quitar (PATCH ?pay=true). "Listar empréstimos quitados?" toggle. dueDate >= transactionDate is enforced client-side and by the server schema. Clone clears _id and suffixes the description with " - Cópia".

Mobile column visibility (hidden md:table-cell) keeps the same five core columns visible on phones as Incomes/Expenses use.

useReferenceData gains an invalidate(key) helper so Account create/edit/toggle refreshes the cached accounts list seen by the Transfer and Loan dialogs.

Three AngularJS navbar entries in static/index.html flipped from ng-click="changeRoute(...)" to href="/app/...". The corresponding Vue navbar items switched from url: to to: so they use router-link.

Orphaned AngularJS controllers/services/HTML for these screens are left in place; they'll be cleaned up in a separate periodic-cleanup pass per the migration recipe.