### PR TITLE
Suppress password-manager autofill on form dialogs

### DIFF
--- a/web/src/views/CategoriesView.vue
+++ b/web/src/views/CategoriesView.vue
@@ -64,7 +64,7 @@
       class="p-datatable-sm"
     >
       <template #footer>{{ rows.length }} registros</template>
-      <Column field="name" header="Nome" sortable />
+      <Column field="name" header="Descrição" sortable />
       <Column field="type" header="Tipo" sortable style="width: 10rem" />
       <Column header="Ativa?" style="width: 6rem" class="text-center">
         <template #body="{ data }">

--- a/web/src/views/accounts/AccountFormDialog.vue
+++ b/web/src/views/accounts/AccountFormDialog.vue
@@ -11,14 +11,22 @@
       <ProgressSpinner style="width: 3rem; height: 3rem" />
     </div>
 
-    <form v-else class="flex flex-col gap-4" @submit.prevent="handleSubmit">
+    <form
+      v-else
+      class="flex flex-col gap-4"
+      data-form-type="other"
+      @submit.prevent="handleSubmit"
+    >
       <div class="flex flex-col gap-1">
-        <label for="accountName" class="text-sm font-medium">Nome</label>
+        <label for="accountLabelInput" class="text-sm font-medium">Nome</label>
         <InputText
-          id="accountName"
+          id="accountLabelInput"
           v-model="form.name"
           :invalid="submitted && !!errors.name"
           autofocus
+          autocomplete="off"
+          data-form-type="other"
+          data-lpignore="true"
         />
         <small v-if="submitted && errors.name" class="text-red-600">{{ errors.name }}</small>
       </div>

--- a/web/src/views/categories/CategoryFormDialog.vue
+++ b/web/src/views/categories/CategoryFormDialog.vue
@@ -11,14 +11,20 @@
       <ProgressSpinner style="width: 3rem; height: 3rem" />
     </div>
 
-    <form v-else class="flex flex-col gap-4" @submit.prevent="handleSubmit">
+    <form
+      v-else
+      class="flex flex-col gap-4"
+      data-form-type="other"
+      @submit.prevent="handleSubmit"
+    >
       <div class="flex flex-col gap-1">
-        <label for="categoryName" class="text-sm font-medium">Nome</label>
+        <label for="categoryName" class="text-sm font-medium">Descrição</label>
         <InputText
           id="categoryName"
           v-model="form.name"
           :invalid="submitted && !!errors.name"
           autofocus
+          autocomplete="off"
         />
         <small v-if="submitted && errors.name" class="text-red-600">{{ errors.name }}</small>
       </div>
@@ -91,9 +97,9 @@ const title = computed(() => (props.mode === 'new' ? 'Adicionar categoria' : 'Ed
 const errors = computed<Record<string, string>>(() => {
   const out: Record<string, string> = {};
   const name = form.name?.trim() ?? '';
-  if (!name) out.name = 'O campo Nome é obrigatório.';
-  else if (name.length < 3) out.name = 'O campo Nome deve possuir no mínimo 3 caracteres.';
-  else if (name.length > 100) out.name = 'O campo Nome deve possuir no máximo 100 caracteres.';
+  if (!name) out.name = 'O campo Descrição é obrigatório.';
+  else if (name.length < 3) out.name = 'O campo Descrição deve possuir no mínimo 3 caracteres.';
+  else if (name.length > 100) out.name = 'O campo Descrição deve possuir no máximo 100 caracteres.';
   if (!form.type) out.type = 'O campo Tipo é obrigatório.';
   return out;
 });

--- a/web/src/views/expenses/ExpenseDetailFormDialog.vue
+++ b/web/src/views/expenses/ExpenseDetailFormDialog.vue
@@ -11,7 +11,12 @@
       <ProgressSpinner style="width: 3rem; height: 3rem" />
     </div>
 
-    <form v-else class="flex flex-col gap-4" @submit.prevent="handleSubmit">
+    <form
+      v-else
+      class="flex flex-col gap-4"
+      data-form-type="other"
+      @submit.prevent="handleSubmit"
+    >
       <div class="flex flex-col gap-1">
         <label for="expenseDetailDescription" class="text-sm font-medium">Descrição</label>
         <InputText
@@ -19,6 +24,7 @@
           v-model="form.description"
           :invalid="submitted && !!errors.description"
           autofocus
+          autocomplete="off"
           maxlength="100"
         />
         <small v-if="submitted && errors.description" class="text-red-600">{{

--- a/web/src/views/expenses/ExpenseFormDialog.vue
+++ b/web/src/views/expenses/ExpenseFormDialog.vue
@@ -11,7 +11,12 @@
       <ProgressSpinner style="width: 3rem; height: 3rem" />
     </div>
 
-    <form v-else class="flex flex-col gap-4" @submit.prevent="handleSubmit">
+    <form
+      v-else
+      class="flex flex-col gap-4"
+      data-form-type="other"
+      @submit.prevent="handleSubmit"
+    >
       <div class="grid grid-cols-12 gap-3">
         <div class="col-span-12 sm:col-span-8 flex flex-col gap-1">
           <label for="expenseDescription" class="text-sm font-medium">Descrição</label>
@@ -20,6 +25,7 @@
             v-model="form.description"
             :invalid="submitted && !!errors.description"
             autofocus
+            autocomplete="off"
             maxlength="100"
           />
           <small v-if="submitted && errors.description" class="text-red-600">{{
@@ -153,7 +159,7 @@
 
       <div class="flex flex-col gap-1">
         <label for="expenseNotes" class="text-sm font-medium">Observações</label>
-        <Textarea id="expenseNotes" v-model="form.notes" rows="2" />
+        <Textarea id="expenseNotes" v-model="form.notes" rows="2" autocomplete="off" />
       </div>
 
       <div class="flex flex-col gap-2">

--- a/web/src/views/expenses/GeneratorFormDialog.vue
+++ b/web/src/views/expenses/GeneratorFormDialog.vue
@@ -11,7 +11,12 @@
       <ProgressSpinner style="width: 3rem; height: 3rem" />
     </div>
 
-    <form v-else class="flex flex-col gap-4" @submit.prevent="handleSubmit">
+    <form
+      v-else
+      class="flex flex-col gap-4"
+      data-form-type="other"
+      @submit.prevent="handleSubmit"
+    >
       <div class="grid grid-cols-12 gap-3">
         <div class="col-span-12 sm:col-span-6 flex flex-col gap-1">
           <label for="genInitialDate" class="text-sm font-medium">Data inicial</label>
@@ -116,6 +121,7 @@
           id="genDescription"
           v-model="form.description"
           maxlength="100"
+          autocomplete="off"
           :invalid="submitted && !!errors.description"
         />
         <small v-if="submitted && errors.description" class="text-red-600">{{
@@ -168,7 +174,7 @@
 
       <div class="flex flex-col gap-1">
         <label for="genNotes" class="text-sm font-medium">Observações</label>
-        <Textarea id="genNotes" v-model="form.notes" rows="1" />
+        <Textarea id="genNotes" v-model="form.notes" rows="1" autocomplete="off" />
       </div>
     </form>
 

--- a/web/src/views/incomes/GeneratorFormDialog.vue
+++ b/web/src/views/incomes/GeneratorFormDialog.vue
@@ -11,7 +11,12 @@
       <ProgressSpinner style="width: 3rem; height: 3rem" />
     </div>
 
-    <form v-else class="flex flex-col gap-4" @submit.prevent="handleSubmit">
+    <form
+      v-else
+      class="flex flex-col gap-4"
+      data-form-type="other"
+      @submit.prevent="handleSubmit"
+    >
       <div class="grid grid-cols-12 gap-3">
         <div class="col-span-12 sm:col-span-6 flex flex-col gap-1">
           <label for="genInitialDate" class="text-sm font-medium">Data inicial</label>
@@ -116,6 +121,7 @@
           id="genDescription"
           v-model="form.description"
           maxlength="100"
+          autocomplete="off"
           :invalid="submitted && !!errors.description"
         />
         <small v-if="submitted && errors.description" class="text-red-600">{{
@@ -168,7 +174,7 @@
 
       <div class="flex flex-col gap-1">
         <label for="genNotes" class="text-sm font-medium">Observações</label>
-        <Textarea id="genNotes" v-model="form.notes" rows="1" />
+        <Textarea id="genNotes" v-model="form.notes" rows="1" autocomplete="off" />
       </div>
     </form>
 

--- a/web/src/views/incomes/IncomeDetailFormDialog.vue
+++ b/web/src/views/incomes/IncomeDetailFormDialog.vue
@@ -11,7 +11,12 @@
       <ProgressSpinner style="width: 3rem; height: 3rem" />
     </div>
 
-    <form v-else class="flex flex-col gap-4" @submit.prevent="handleSubmit">
+    <form
+      v-else
+      class="flex flex-col gap-4"
+      data-form-type="other"
+      @submit.prevent="handleSubmit"
+    >
       <div class="flex flex-col gap-1">
         <label for="incomeDetailDescription" class="text-sm font-medium">Descrição</label>
         <InputText
@@ -19,6 +24,7 @@
           v-model="form.description"
           :invalid="submitted && !!errors.description"
           autofocus
+          autocomplete="off"
           maxlength="100"
         />
         <small v-if="submitted && errors.description" class="text-red-600">{{

--- a/web/src/views/incomes/IncomeFormDialog.vue
+++ b/web/src/views/incomes/IncomeFormDialog.vue
@@ -11,7 +11,12 @@
       <ProgressSpinner style="width: 3rem; height: 3rem" />
     </div>
 
-    <form v-else class="flex flex-col gap-4" @submit.prevent="handleSubmit">
+    <form
+      v-else
+      class="flex flex-col gap-4"
+      data-form-type="other"
+      @submit.prevent="handleSubmit"
+    >
       <div class="flex flex-col gap-1">
         <label for="incomeDescription" class="text-sm font-medium">Descrição</label>
         <InputText
@@ -19,6 +24,7 @@
           v-model="form.description"
           :invalid="submitted && !!errors.description"
           autofocus
+          autocomplete="off"
           maxlength="100"
         />
         <small v-if="submitted && errors.description" class="text-red-600">{{
@@ -141,7 +147,7 @@
 
       <div class="flex flex-col gap-1">
         <label for="incomeNotes" class="text-sm font-medium">Observações</label>
-        <Textarea id="incomeNotes" v-model="form.notes" rows="2" />
+        <Textarea id="incomeNotes" v-model="form.notes" rows="2" autocomplete="off" />
       </div>
 
       <div class="flex flex-col gap-2">

--- a/web/src/views/loans/LoanFormDialog.vue
+++ b/web/src/views/loans/LoanFormDialog.vue
@@ -11,7 +11,12 @@
       <ProgressSpinner style="width: 3rem; height: 3rem" />
     </div>
 
-    <form v-else class="flex flex-col gap-4" @submit.prevent="handleSubmit">
+    <form
+      v-else
+      class="flex flex-col gap-4"
+      data-form-type="other"
+      @submit.prevent="handleSubmit"
+    >
       <div class="flex flex-col gap-1">
         <label for="loanDescription" class="text-sm font-medium">Descrição</label>
         <InputText
@@ -19,6 +24,7 @@
           v-model="form.description"
           :invalid="submitted && !!errors.description"
           autofocus
+          autocomplete="off"
         />
         <small v-if="submitted && errors.description" class="text-red-600">{{
           errors.description
@@ -130,7 +136,7 @@
 
       <div class="flex flex-col gap-1">
         <label for="loanNotes" class="text-sm font-medium">Observações</label>
-        <Textarea id="loanNotes" v-model="form.notes" rows="3" auto-resize />
+        <Textarea id="loanNotes" v-model="form.notes" rows="3" auto-resize autocomplete="off" />
       </div>
     </form>
 

--- a/web/src/views/transfers/TransferFormDialog.vue
+++ b/web/src/views/transfers/TransferFormDialog.vue
@@ -11,7 +11,12 @@
       <ProgressSpinner style="width: 3rem; height: 3rem" />
     </div>
 
-    <form v-else class="flex flex-col gap-4" @submit.prevent="handleSubmit">
+    <form
+      v-else
+      class="flex flex-col gap-4"
+      data-form-type="other"
+      @submit.prevent="handleSubmit"
+    >
       <div class="flex flex-col gap-1 sm:w-48">
         <label for="transferDate" class="text-sm font-medium">Data</label>
         <DatePicker


### PR DESCRIPTION
NordPass (and similar managers) were offering credential/contact-info fill on description and name fields. Add data-form-type="other" on each form and autocomplete="off" on every InputText/Textarea — Chrome ignores autocomplete=off for non-credential text inputs so saved-value suggestions still work, but password managers respect it. Rename the Categories "Nome" label to "Descrição" since NordPass's identity classifier was matching on the visible label text.