### PR TITLE
Show status as icon-only column on Incomes/Expenses grids

### DIFF
--- a/web/src/views/ExpensesView.vue
+++ b/web/src/views/ExpensesView.vue
@@ -183,7 +183,18 @@
         class="hidden md:table-cell"
         header-class="hidden md:table-cell"
       />
-      <Column field="status" header="Situação" sortable style="width: 7rem" class="text-center" />
+      <Column field="status" sortable style="width: 4rem" class="text-center">
+        <template #header>
+          <i
+            class="pi pi-money-bill text-lg"
+            aria-label="Pago"
+            v-tooltip.bottom="'Pago'"
+          />
+        </template>
+        <template #body="{ data }">
+          <i v-if="data.status === 'Pago'" class="pi pi-check text-green-600" />
+        </template>
+      </Column>
       <Column
         field="amountPaid"
         header="Valor pago"

--- a/web/src/views/IncomesView.vue
+++ b/web/src/views/IncomesView.vue
@@ -183,7 +183,18 @@
         class="hidden md:table-cell"
         header-class="hidden md:table-cell"
       />
-      <Column field="status" header="Situação" sortable style="width: 7rem" class="text-center" />
+      <Column field="status" sortable style="width: 4rem" class="text-center">
+        <template #header>
+          <i
+            class="pi pi-wallet text-lg"
+            aria-label="Recebido"
+            v-tooltip.bottom="'Recebido'"
+          />
+        </template>
+        <template #body="{ data }">
+          <i v-if="data.status === 'Recebido'" class="pi pi-check text-green-600" />
+        </template>
+      </Column>
       <Column
         field="amountReceived"
         header="Valor receb."


### PR DESCRIPTION
Shrinks the column from 7rem to 4rem (matching the Agendado pattern), which offsets the kebab column added in #recent and removes the mobile horizontal scroll. Header uses pi-money-bill (Pago) and pi-wallet (Recebido); body shows pi-check when paid/received, empty otherwise.