### PR TITLE
chore: drop /app/ URL prefix; serve SPA from /

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,10 +11,10 @@ Guidelines for AI agents working in this repo. Read [docs/ARCHITECTURE.md](./doc
 
 ## Project shape
 
-- Vue 3 + Vite + PrimeVue (Aura) + Tailwind v4 + TypeScript SPA at `/app/*` (source: `web/src/`). All screens — including Login/Logoff — live here.
+- Vue 3 + Vite + PrimeVue (Aura) + Tailwind v4 + TypeScript SPA served from `/` (source: `web/src/`). All screens — including Login/Logoff — live here.
 - Node/Express backend in `api/` (api → service → model layers) with MongoDB via Mongoose. Auth is Google OAuth2 producing an opaque token in `Authorization`, with `User-Id` alongside.
-- OAuth callback redirects to `/app/#id=...&token=...`; `consumeOAuthHash()` (defined in `web/src/lib/session.ts`) is invoked at the top of `web/src/router.ts`, before `createWebHistory` — Vue Router snapshots `window.location` on history creation, so the hash must be parsed and stripped first. It writes the `loggedUser*` keys to `localStorage`. The router's `beforeEach` guard then sends unauthenticated requests to `/login` (routes flagged `meta.public: true` are exempt).
-- Bare `/`, `/login`, `/logoff` 302-redirect to `/app/...` server-side so old links keep working.
+- OAuth callback redirects to `/#id=...&token=...`; `consumeOAuthHash()` (defined in `web/src/lib/session.ts`) is invoked at the top of `web/src/router.ts`, before `createWebHistory` — Vue Router snapshots `window.location` on history creation, so the hash must be parsed and stripped first. It writes the `loggedUser*` keys to `localStorage`. The router's `beforeEach` guard then sends unauthenticated requests to `/login` (routes flagged `meta.public: true` are exempt).
+- Legacy `/app/*` URLs (the prefix used during the AngularJS → Vue migration) 302-redirect to `/*` so old bookmarks keep working.
 
 ## Gotchas
 
@@ -24,7 +24,7 @@ Guidelines for AI agents working in this repo. Read [docs/ARCHITECTURE.md](./doc
 - **Lockfile:** `web/.npmrc` has `package-lock=false` because Tailwind v4's native bindings hit npm bug #4828 with platform-pinned lockfiles. Don't add a `package-lock.json` under `web/`.
 - **Node version:** Vue build needs Node 20+. The Express server is fine on Node 18+.
 - **Shared dropdowns:** module-singleton cache in `web/src/composables/useReferenceData.ts` (currencies, accounts, categories-by-type). Defer Pinia until cross-screen reactive invalidation is actually needed.
-- **Logoff does a full reload:** `LogoffView` calls `window.location.assign('/app/login')` after the API call so `AppNavbar` (mounted in `App.vue`, captures session at setup) re-renders with cleared state. Don't replace this with `router.push` unless you also make the navbar reactive to session changes.
+- **Logoff does a full reload:** `LogoffView` calls `window.location.assign('/login')` after the API call so `AppNavbar` (mounted in `App.vue`, captures session at setup) re-renders with cleared state. Don't replace this with `router.push` unless you also make the navbar reactive to session changes.
 
 ## Local dev
 

--- a/api/apis/authApi.js
+++ b/api/apis/authApi.js
@@ -71,13 +71,13 @@ module.exports = function (app, url, passport, GoogleStrategy) {
     });
 
     app.get('/auth/google/callback',
-        passport.authenticate('google', { failureRedirect: '/app/login', session: false }),
+        passport.authenticate('google', { failureRedirect: '/login', session: false }),
         function (req, res) {
             let user = req.user;
 
             if (!user) {
                 var message = encodeURIComponent('Authentication failed');
-                return res.redirect('/app/login?error=' + message);
+                return res.redirect('/login?error=' + message);
             }
 
             var params = [
@@ -88,7 +88,7 @@ module.exports = function (app, url, passport, GoogleStrategy) {
                 'photo=' + encodeURIComponent(user.photo)
             ].join('&');
 
-            return res.redirect('/app/#' + params);
+            return res.redirect('/#' + params);
         });
 
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,13 +18,13 @@ Personal finance tracker: expenses, incomes, transfers, loans, and balances acro
 ```mermaid
 flowchart LR
     User([User])
-    Browser[Vue 3 SPA<br/>web/dist served at /app/*]
+    Browser[Vue 3 SPA<br/>web/dist served at /]
     Server[Express server<br/>server.js :8500]
     Mongo[(MongoDB<br/>finance-control)]
     Google[Google OAuth2]
 
     User -->|HTTPS| Browser
-    Browser -->|GET /app/*| Server
+    Browser -->|GET /| Server
     Browser -->|/api/* + Authorization, User-Id| Server
     Server -->|Mongoose| Mongo
     Server -->|/auth/google| Google
@@ -36,7 +36,7 @@ flowchart LR
     end
 ```
 
-The Node process serves both the Vue SPA (built into `web/dist/`) and the JSON API from the same origin and port. The Vue build runs inside `docker/web/Dockerfile`'s multi-stage `web-builder` stage; bare `/`, `/login`, `/logoff` 302-redirect to `/app/...` so legacy bookmarks keep working.
+The Node process serves both the Vue SPA (built into `web/dist/`) and the JSON API from the same origin and port. The Vue build runs inside `docker/web/Dockerfile`'s multi-stage `web-builder` stage. Legacy `/app/*` URLs (the prefix used during the AngularJS → Vue migration) 302-redirect to the equivalent root path so old bookmarks keep working.
 
 ## Backend module layout
 
@@ -147,7 +147,7 @@ sequenceDiagram
     G->>API: GET /auth/google/callback?code=...
     API->>G: Exchange code for profile
     API->>DB: usersService.logIn — upsert user, push new token
-    API-->>SPA: Redirect to /app/#id&token&name&email&photo
+    API-->>SPA: Redirect to /#id&token&name&email&photo
     SPA->>SPA: consumeOAuthHash() stores in localStorage; router guard allows
     Note over SPA,API: All later requests carry<br/>Authorization: <token>, User-Id: <id>
     SPA->>API: GET /api/expenses (with headers)
@@ -164,7 +164,7 @@ Tokens are opaque random strings stored in an array on the user document, so mul
 | Concern         | Location                                     |
 | --------------- | -------------------------------------------- |
 | Entrypoint      | `web/src/main.ts` (createApp + plugins, mounts `#app`) |
-| Routing & guard | `web/src/router.ts` (base `/app/`, `meta.public`; calls `consumeOAuthHash()` at module load, before `createWebHistory`) |
+| Routing & guard | `web/src/router.ts` (HTML5 history at `/`, `meta.public`; calls `consumeOAuthHash()` at module load, before `createWebHistory`) |
 | Views           | `web/src/views/*.vue` + `views/<resource>/<Resource>FormDialog.vue` |
 | Composables     | `web/src/composables/*.ts` (CRUD wrappers, theme, isMobile, ...) |
 | API client      | `web/src/lib/api.ts` (axios + auth interceptor) |
@@ -172,7 +172,7 @@ Tokens are opaque random strings stored in an array on the user document, so mul
 | Navbar          | `web/src/components/AppNavbar.vue`           |
 | Theme + locale  | `web/src/primevue.ts`                        |
 
-Vue Router routes mirror the backend resources (`/expenses`, `/incomes`, `/accounts`, `/categories`, `/transfers`, `/loans`) plus `/`, `/login`, `/logoff`. The router's global `beforeEach` redirects unauthenticated requests to `/login` (routes flagged `meta.public: true` are exempt). The axios response interceptor calls `window.location.assign('/app/login')` on 401 from any API call.
+Vue Router routes mirror the backend resources (`/expenses`, `/incomes`, `/accounts`, `/categories`, `/transfers`, `/loans`) plus `/`, `/login`, `/logoff`. The router's global `beforeEach` redirects unauthenticated requests to `/login` (routes flagged `meta.public: true` are exempt). The axios response interceptor calls `window.location.assign('/login')` on 401 from any API call.
 
 ## Deployment
 
@@ -224,7 +224,7 @@ sequenceDiagram
 
 ```
 finance-control/
-├── server.js                  # Express bootstrap, route registration, /app/* SPA fallback, legacy redirects
+├── server.js                  # Express bootstrap, route registration, root SPA fallback, /app/* legacy redirect
 ├── package.json               # Node 18+, no test scripts; build:web shortcut
 ├── docker-compose.yml         # local dev (web + web-frontend Vite + mongodb)
 ├── docker-compose-server.yml  # production
@@ -236,9 +236,9 @@ finance-control/
 ├── web/
 │   ├── package.json           # Vue 3, PrimeVue 4, Tailwind v4, Vite, TypeScript
 │   ├── .npmrc                 # package-lock=false (Tailwind v4 / npm bug #4828)
-│   ├── vite.config.ts         # base '/app/', proxies /api + /auth to Express
+│   ├── vite.config.ts         # base '/', proxies /api + /auth to Express
 │   ├── index.html
-│   ├── public/                # favicon, etc. (copied to /app/ at build time)
+│   ├── public/                # favicon, etc. (copied to /dist at build time)
 │   └── src/
 │       ├── main.ts            # createApp + plugins, mounts #app
 │       ├── App.vue            # AppNavbar + Toast + ConfirmDialog + RouterView

--- a/docs/UI_MIGRATION.md
+++ b/docs/UI_MIGRATION.md
@@ -1,6 +1,6 @@
 # UI migration: AngularJS → Vue 3
 
-The frontend migration from AngularJS 1.x + Bower + Bootstrap 3 + ui-grid to Vue 3 + Vite + PrimeVue + Tailwind is **complete**. The `static/` directory has been deleted; Express serves only the Vue SPA at `/app/*` plus the JSON API.
+The frontend migration from AngularJS 1.x + Bower + Bootstrap 3 + ui-grid to Vue 3 + Vite + PrimeVue + Tailwind is **complete**. The `static/` directory has been deleted; Express serves only the Vue SPA at `/` plus the JSON API. The `/app/` prefix used during the migration has been removed; `/app/*` URLs 302-redirect to the equivalent root path for backward compatibility.
 
 Read [ARCHITECTURE.md](./ARCHITECTURE.md) first for the overall system context.
 
@@ -9,14 +9,14 @@ Read [ARCHITECTURE.md](./ARCHITECTURE.md) first for the overall system context.
 | Concern             | Choice                                                          |
 | ------------------- | --------------------------------------------------------------- |
 | Framework           | Vue 3 (Composition API) + TypeScript                            |
-| Build               | Vite, output to `web/dist/`, base path `/app/`                  |
+| Build               | Vite, output to `web/dist/`, base path `/`                      |
 | Component library   | PrimeVue 4 (Aura preset, light/dark via `.dark` selector)       |
 | Styling             | Tailwind v4 utilities for layout/spacing only                   |
 | Icons               | PrimeIcons                                                      |
-| Routing             | Vue Router (`createWebHistory('/app/')`) with public/private guard |
+| Routing             | Vue Router (HTML5 history at `/`) with public/private guard     |
 | State               | Composables in `web/src/composables/`; Pinia not yet needed     |
 | HTTP                | axios instance with auth-bridge interceptor                     |
-| Auth                | Google OAuth → callback redirects to `/app/#id=...&token=...`; `consumeOAuthHash()` in `web/src/lib/session.ts` parses and stores |
+| Auth                | Google OAuth → callback redirects to `/#id=...&token=...`; `consumeOAuthHash()` in `web/src/lib/session.ts` parses and stores |
 | Lockfile            | **Disabled** in `web/.npmrc` (`package-lock=false`) — see Gotchas |
 
 ## Routing
@@ -24,10 +24,8 @@ Read [ARCHITECTURE.md](./ARCHITECTURE.md) first for the overall system context.
 ```
 /api/*         → Express JSON API
 /auth/*        → Google OAuth + logoff endpoints
-/app/*         → Vue SPA (web/dist)
-/, /login,     → 302 redirect to /app/, /app/login, /app/logoff
-/logoff
-anything else  → 302 redirect to /app/
+/app/*         → 302 redirect to the equivalent path under / (legacy)
+anything else  → Vue SPA (web/dist), with client-side routing
 ```
 
 The Vue router has a `beforeEach` guard that bounces unauthenticated requests to `/login`, except for routes flagged `meta.public: true` (`/login`, `/logoff`).
@@ -51,7 +49,7 @@ The Vue router has a `beforeEach` guard that bounces unauthenticated requests to
 
 | Mode | Command | URL |
 | ---- | ------- | --- |
-| Dev (HMR)               | `docker compose up --build`                                                | `http://localhost:5173/app/` (Vite proxies `/api`+`/auth` to Express on `:8500`) |
+| Dev (HMR)               | `docker compose up --build`                                                | `http://localhost:5173/` (Vite proxies `/api`+`/auth` to Express on `:8500`) |
 | Integrated smoke test   | `npm run build:web && docker compose up --build`                           | `http://localhost:8500/` |
 | Production              | `docker compose -f docker-compose-server.yml up --build` (Portainer)       | port 8500 |
 
@@ -95,10 +93,10 @@ docker compose up --build
 
 ```
 finance-control/
-  server.js                          # Express: /api, /auth, /app/* SPA, redirects for /, /login, /logoff
+  server.js                          # Express: /api, /auth, root SPA fallback, /app/* legacy redirect
   web/                               # Vue 3 app
     package.json
-    vite.config.ts                   # base: '/app/', proxy /api+/auth → Express
+    vite.config.ts                   # base: '/', proxy /api+/auth → Express
     tsconfig.json
     .npmrc                           # package-lock=false
     index.html
@@ -111,7 +109,7 @@ finance-control/
       primevue.ts                    # Theme + pt-BR locale
       style.css
       lib/
-        api.ts                       # axios + auth interceptor + 401 redirect to /app/login
+        api.ts                       # axios + auth interceptor + 401 redirect to /login
         session.ts                   # getSession(), isLoggedIn(), consumeOAuthHash()
       components/
         AppNavbar.vue                # PrimeVue Menubar (hidden when not logged in)

--- a/server.js
+++ b/server.js
@@ -42,7 +42,8 @@ require('./api/apis/currenciesApi.js')(app, url);
 // AngularJS → Vue migration; this redirect keeps old bookmarks working.
 app.get(/^\/app(\/.*)?$/, function (req, res) {
     var subpath = req.url.replace(/^\/app/, '') || '/';
-    res.redirect(subpath);
+    var safeSubpath = ('/' + subpath).replace(/^\/+/, '/');
+    res.redirect(safeSubpath);
 });
 
 // SPA HTML fallback for client-routed paths (/expenses, /login, ...).

--- a/server.js
+++ b/server.js
@@ -38,12 +38,21 @@ require('./api/apis/usersApi.js')(app, url);
 require('./api/apis/loansApi.js')(app, url);
 require('./api/apis/currenciesApi.js')(app, url);
 
+function isSafeLocalRedirectPath(pathname) {
+    if (typeof pathname !== 'string') return false;
+    if (!pathname.startsWith('/') || pathname.startsWith('//')) return false;
+    if (pathname.indexOf('\\') !== -1) return false;
+    if (pathname.indexOf('..') !== -1) return false;
+    if (/[\u0000-\u001F\u007F]/.test(pathname)) return false;
+    return /^\/[A-Za-z0-9\-._~!$&'()*+,;=:@/?%]*$/.test(pathname);
+}
+
 // Legacy /app/* → strip prefix. The SPA used to live under /app/ during the
 // AngularJS → Vue migration; this redirect keeps old bookmarks working.
 app.get(/^\/app(\/.*)?$/, function (req, res) {
     var subpath = req.url.replace(/^\/app/, '') || '/';
     var safeSubpath = ('/' + subpath).replace(/^\/+/, '/');
-    res.redirect(safeSubpath);
+    res.redirect(isSafeLocalRedirectPath(safeSubpath) ? safeSubpath : '/');
 });
 
 // SPA HTML fallback for client-routed paths (/expenses, /login, ...).

--- a/server.js
+++ b/server.js
@@ -17,7 +17,7 @@ var promise = mongoose.connect(databaseUrl, { useNewUrlParser: true, useUnifiedT
 app.set('trust proxy', 1);
 app.disable('x-powered-by');
 
-app.use('/app', express.static(__dirname + '/web/dist'))
+app.use(express.static(__dirname + '/web/dist'))
 app.use(morgan('dev'));
 app.use(bodyParser.urlencoded({ extended: true, limit: '1mb' }));
 app.use(bodyParser.json({ limit: '1mb' }));
@@ -38,29 +38,17 @@ require('./api/apis/usersApi.js')(app, url);
 require('./api/apis/loansApi.js')(app, url);
 require('./api/apis/currenciesApi.js')(app, url);
 
-// Static pages requests =======================================================
-app.get(/^\/app(\/.*)?$/, function(req, res){
+// Legacy /app/* → strip prefix. The SPA used to live under /app/ during the
+// AngularJS → Vue migration; this redirect keeps old bookmarks working.
+app.get(/^\/app(\/.*)?$/, function (req, res) {
+    var subpath = req.url.replace(/^\/app/, '') || '/';
+    res.redirect(subpath);
+});
+
+// SPA HTML fallback for client-routed paths (/expenses, /login, ...).
+// Excludes /api/* and /auth/* so unmatched API routes 404 normally.
+app.get(/^\/(?!api\/|auth\/|app(\/|$)).*$/, function (req, res) {
     res.sendFile(__dirname + '/web/dist/index.html');
-});
-
-// Legacy entrypoints redirect into the Vue SPA so existing bookmarks and
-// OAuth failure-redirect targets keep working after AngularJS was retired.
-app.get('/', function (req, res) {
-    res.redirect('/app/');
-});
-
-app.get('/login', function (req, res) {
-    var qs = req.url.indexOf('?');
-    res.redirect('/app/login' + (qs >= 0 ? req.url.slice(qs) : ''));
-});
-
-app.get('/logoff', function (req, res) {
-    var qs = req.url.indexOf('?');
-    res.redirect('/app/logoff' + (qs >= 0 ? req.url.slice(qs) : ''));
-});
-
-app.use(function (req, res) {
-    res.redirect('/app/');
 });
 
 // listen (start app with node server.js) ======================================

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -20,7 +20,7 @@ api.interceptors.response.use(
   (response) => response,
   (error: AxiosError) => {
     if (error.response?.status === 401) {
-      window.location.assign('/app/login');
+      window.location.assign('/login');
     }
     return Promise.reject(error);
   },

--- a/web/src/router.ts
+++ b/web/src/router.ts
@@ -16,7 +16,7 @@ import { consumeOAuthHash, isLoggedIn } from './lib/session';
 consumeOAuthHash();
 
 const router = createRouter({
-  history: createWebHistory('/app/'),
+  history: createWebHistory(),
   routes: [
     { path: '/', name: 'home', component: HomeView },
     { path: '/categories', name: 'categories', component: CategoriesView },

--- a/web/src/views/LogoffView.vue
+++ b/web/src/views/LogoffView.vue
@@ -21,6 +21,6 @@ onMounted(async () => {
   }
   clearSession();
   // Full navigation so the navbar (mounted in App.vue) reflects the cleared session.
-  window.location.assign('/app/login');
+  window.location.assign('/login');
 });
 </script>

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -6,7 +6,7 @@ const apiTarget = process.env.VITE_API_TARGET || 'http://web:8500';
 
 export default defineConfig({
   plugins: [vue(), tailwindcss()],
-  base: '/app/',
+  base: '/',
   server: {
     host: '0.0.0.0',
     port: 5173,


### PR DESCRIPTION
## Summary

The `/app/` URL prefix was scaffolding to let AngularJS (at `/`) and Vue (at `/app/`) coexist during the migration. Now that AngularJS is gone (commit \`c70001f\`), the prefix is dead weight. This PR collapses the SPA to `/`.

- `vite.config.ts` base, `createWebHistory()`, axios 401 redirect, `LogoffView` redirect, and the three OAuth-callback redirect targets in \`authApi.js\` all switch from \`/app/*\` to \`/*\`.
- `server.js`: static middleware mounts at root; SPA HTML fallback regex excludes \`/api\`, \`/auth\`, and \`/app\` so unmatched API paths still 404 cleanly.
- **Legacy redirects are inverted:** `/app/*` now 302s to the equivalent root path (handled by a single regex), so any old bookmarks keep resolving.
- Docs, mermaid diagrams, and file trees in `CLAUDE.md`, `docs/ARCHITECTURE.md`, `docs/UI_MIGRATION.md` updated to reflect the new shape.

`GOOGLE_CALLBACK_URL` is unchanged — the callback path itself (`/auth/google/callback`) was always at root.

Stacks on top of #36 (no functional dependency, but both touch the same docs — minor merge expected).

## Test plan

- [ ] `cd web && npx vue-tsc --noEmit` — passes (verified locally)
- [ ] `docker compose up --build` — visit `http://localhost:5173/`, SPA loads
- [ ] OAuth login round-trip: \`http://localhost:8500/\` → /login → Google → callback → lands on `/` with hash consumed and home view rendered
- [ ] `curl -I http://localhost:8500/app/expenses` returns `302 → /expenses`
- [ ] `curl -I http://localhost:8500/app/login` returns `302 → /login`
- [ ] `curl -I http://localhost:8500/api/nope` returns `404` (not the SPA HTML)
- [ ] Logoff: navbar logoff → full reload to `/login`, navbar hidden
- [ ] 401 handling: clear `loggedUserToken` from localStorage, refresh — bounces to `/login`

🤖 Generated with [Claude Code](https://claude.com/claude-code)