### PR TITLE
Show Quitado status as icon on loans table

### DIFF
--- a/web/src/views/LoansView.vue
+++ b/web/src/views/LoansView.vue
@@ -132,7 +132,18 @@
         class="text-center hidden md:table-cell"
         header-class="hidden md:table-cell"
       />
-      <Column field="status" header="Situação" sortable style="width: 8rem" class="text-center" />
+      <Column field="status" sortable style="width: 4rem" class="text-center">
+        <template #header>
+          <i
+            class="pi pi-money-bill text-lg"
+            aria-label="Quitado"
+            v-tooltip.bottom="'Quitado'"
+          />
+        </template>
+        <template #body="{ data }">
+          <i v-if="data.status === 'Quitado'" class="pi pi-check text-green-600" />
+        </template>
+      </Column>
       <Column
         class="md:hidden text-center"
         header-class="md:hidden"


### PR DESCRIPTION
## Summary
- Replace the `Situação` text column in `LoansView.vue` with a narrow icon column matching the expenses/incomes pattern: `pi pi-money-bill` header (tooltip "Quitado") and a green `pi pi-check` body when `status === 'Quitado'`.

## Test plan
- [ ] Open the loans screen, confirm the new icon column header and the check appears only on quitados.
- [ ] Verify column still sorts on `status`.
- [ ] Check on mobile viewport that the column stays compact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)