### PR TITLE
Use percentage widths for transfers Data/Valor on mobile

### DIFF
--- a/web/src/views/TransfersView.vue
+++ b/web/src/views/TransfersView.vue
@@ -116,7 +116,12 @@
       class="p-datatable-sm"
       @row-contextmenu="onRowContext"
     >
-      <Column field="date" header="Data" sortable style="width: 9rem" class="text-center">
+      <Column
+        field="date"
+        header="Data"
+        sortable
+        class="text-center w-1/4 md:w-36"
+      >
         <template #body="{ data }">{{ formatShortDate(data.date) }}</template>
         <template #footer>{{ rows.length }} registros</template>
       </Column>
@@ -124,7 +129,7 @@
         field="amount"
         header="Valor"
         sortable
-        style="width: 11rem"
+        class="w-1/4 md:w-44"
         header-class="header-end"
       >
         <template #body="{ data }">


### PR DESCRIPTION
## Summary
- On `TransfersView`, drop the fixed `9rem`/`11rem` inline widths from the `Data` and `Valor` columns and use Tailwind responsive classes: `w-1/4` on mobile (25% each), `md:w-36` / `md:w-44` from md+ to preserve the desktop sizing. `Conta Origem` (no width set) absorbs the remaining space, which on small screens means it now actually has room to render.

## Test plan
- [ ] On mobile viewport, confirm `Data` ≈ 25%, `Valor` ≈ 25%, `Conta Origem` takes the rest, and the row-action `…` button still fits.
- [ ] On md+ viewport, confirm widths are unchanged from before (9rem / 11rem) and `Conta Destino` remains visible.
- [ ] Sort/filter still works on `Data` and `Valor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)