### PR TITLE
Use percentage widths for categories Tipo/Ativa on mobile

### DIFF
--- a/web/src/views/CategoriesView.vue
+++ b/web/src/views/CategoriesView.vue
@@ -71,8 +71,8 @@
     >
       <template #footer>{{ rows.length }} registros</template>
       <Column field="name" header="Descrição" sortable />
-      <Column field="type" header="Tipo" sortable style="width: 10rem" />
-      <Column header="Ativa?" style="width: 6rem" class="text-center">
+      <Column field="type" header="Tipo" sortable class="w-1/4 md:w-40" />
+      <Column header="Ativa?" class="text-center w-1/4 md:w-24">
         <template #body="{ data }">
           <i
             :class="data.enabled ? 'pi pi-check text-green-600' : 'pi pi-times text-red-600'"


### PR DESCRIPTION
## Summary
- On `CategoriesView`, drop the fixed `10rem`/`6rem` inline widths from `Tipo` and `Ativa?` and use Tailwind responsive classes: `w-1/4` on mobile (25% each), `md:w-40` / `md:w-24` from md+ to keep desktop sizing. `Descrição` (no width set) absorbs the remaining space, which on small screens means it stops being squeezed by the fixed columns.

## Test plan
- [ ] On mobile viewport, confirm `Tipo` ≈ 25%, `Ativa?` ≈ 25%, `Descrição` takes the rest.
- [ ] On md+ viewport, confirm widths are unchanged from before (10rem / 6rem).
- [ ] Sort still works on `Descrição` and `Tipo`; `Ativa?` icon still renders centered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)