### PR TITLE
Use fixed widths for categories and loans cols

### DIFF
--- a/web/src/views/AccountsView.vue
+++ b/web/src/views/AccountsView.vue
@@ -75,7 +75,7 @@
         field="initialBalance"
         header="Saldo inicial"
         sortable
-        style="width: 11rem"
+        style="width: 8rem"
         header-class="header-end"
       >
         <template #body="{ data }">
@@ -92,7 +92,7 @@
         class="text-center hidden md:table-cell"
         header-class="hidden md:table-cell"
       />
-      <Column header="Ativa?" style="width: 6rem" class="text-center">
+      <Column header="Ativa?" style="width: 5rem" class="text-center">
         <template #body="{ data }">
           <i
             :class="data.enabled ? 'pi pi-check text-green-600' : 'pi pi-times text-red-600'"

--- a/web/src/views/CategoriesView.vue
+++ b/web/src/views/CategoriesView.vue
@@ -72,7 +72,7 @@
       <template #footer>{{ rows.length }} registros</template>
       <Column field="name" header="Descrição" sortable />
       <Column field="type" header="Tipo" sortable style="width: 7rem" />
-      <Column header="Ativa?" style="width: 7rem" class="text-center">
+      <Column header="Ativa?" style="width: 5rem" class="text-center">
         <template #body="{ data }">
           <i
             :class="data.enabled ? 'pi pi-check text-green-600' : 'pi pi-times text-red-600'"

--- a/web/src/views/CategoriesView.vue
+++ b/web/src/views/CategoriesView.vue
@@ -71,8 +71,8 @@
     >
       <template #footer>{{ rows.length }} registros</template>
       <Column field="name" header="Descrição" sortable />
-      <Column field="type" header="Tipo" sortable class="w-1/4 md:w-40" />
-      <Column header="Ativa?" class="text-center w-1/4 md:w-24">
+      <Column field="type" header="Tipo" sortable style="width: 7rem" />
+      <Column header="Ativa?" style="width: 7rem" class="text-center">
         <template #body="{ data }">
           <i
             :class="data.enabled ? 'pi pi-check text-green-600' : 'pi pi-times text-red-600'"

--- a/web/src/views/ExpensesView.vue
+++ b/web/src/views/ExpensesView.vue
@@ -145,7 +145,7 @@
       class="p-datatable-sm"
       @row-contextmenu="onRowContext"
     >
-      <Column field="dueDate" header="Vencimento" sortable style="width: 9rem" class="text-center">
+      <Column field="dueDate" header="Vencimento" sortable style="width: 7rem" class="text-center">
         <template #body="{ data }">{{ formatShortDate(data.dueDate) }}</template>
       </Column>
       <Column field="description" header="Descrição" sortable>
@@ -155,7 +155,7 @@
         field="amount"
         header="Valor"
         sortable
-        style="width: 10rem"
+        style="width: 7rem"
         header-class="header-end"
       >
         <template #body="{ data }">

--- a/web/src/views/IncomesView.vue
+++ b/web/src/views/IncomesView.vue
@@ -145,7 +145,7 @@
       class="p-datatable-sm"
       @row-contextmenu="onRowContext"
     >
-      <Column field="dueDate" header="Vencimento" sortable style="width: 9rem" class="text-center">
+      <Column field="dueDate" header="Vencimento" sortable style="width: 7rem" class="text-center">
         <template #body="{ data }">{{ formatShortDate(data.dueDate) }}</template>
       </Column>
       <Column field="description" header="Descrição" sortable>
@@ -155,7 +155,7 @@
         field="amount"
         header="Valor"
         sortable
-        style="width: 10rem"
+        style="width: 7rem"
         header-class="header-end"
       >
         <template #body="{ data }">

--- a/web/src/views/LoansView.vue
+++ b/web/src/views/LoansView.vue
@@ -86,7 +86,7 @@
         field="transactionDate"
         header="Data"
         sortable
-        style="width: 9rem"
+        style="width: 7rem"
         class="text-center"
       >
         <template #body="{ data }">{{ formatShortDate(data.transactionDate) }}</template>
@@ -105,7 +105,7 @@
         field="amount"
         header="Valor"
         sortable
-        style="width: 11rem"
+        style="width: 7rem"
         header-class="header-end"
       >
         <template #body="{ data }">

--- a/web/src/views/LoansView.vue
+++ b/web/src/views/LoansView.vue
@@ -86,7 +86,7 @@
         field="transactionDate"
         header="Data"
         sortable
-        style="width: 7rem"
+        style="width: 5rem"
         class="text-center"
       >
         <template #body="{ data }">{{ formatShortDate(data.transactionDate) }}</template>

--- a/web/src/views/TransfersView.vue
+++ b/web/src/views/TransfersView.vue
@@ -116,7 +116,7 @@
       class="p-datatable-sm"
       @row-contextmenu="onRowContext"
     >
-      <Column field="date" header="Data" sortable style="width: 9rem" class="text-center">
+      <Column field="date" header="Data" sortable style="width: 7rem" class="text-center">
         <template #body="{ data }">{{ formatShortDate(data.date) }}</template>
         <template #footer>{{ rows.length }} registros</template>
       </Column>
@@ -124,7 +124,7 @@
         field="amount"
         header="Valor"
         sortable
-        style="width: 9rem"
+        style="width: 7rem"
         header-class="header-end"
       >
         <template #body="{ data }">


### PR DESCRIPTION
Reverts the percentage-width approach and uses fixed widths:
- CategoriesView: `7rem` for Tipo and Ativa
- LoansView: `7rem` for Data and Valor
- TransfersView: `7rem` for Data and Valor