### PR TITLE
Move theme picker from navbar into Settings dialog

### DIFF
--- a/web/src/components/AppNavbar.vue
+++ b/web/src/components/AppNavbar.vue
@@ -52,16 +52,6 @@
           @click="settingsDialogVisible = true"
         />
         <Button
-          :icon="themeIcon"
-          severity="secondary"
-          text
-          rounded
-          :aria-label="$t('navbar.theme')"
-          v-tooltip.bottom="themeTooltip"
-          @click="toggleThemeMenu"
-        />
-        <Menu ref="themeMenu" :model="themeItems" :popup="true" />
-        <Button
           icon="pi pi-sign-out"
           severity="secondary"
           text
@@ -85,13 +75,11 @@ import Menu from 'primevue/menu';
 import Button from 'primevue/button';
 import type { MenuItem } from 'primevue/menuitem';
 import { getSession, isLoggedIn } from '../lib/session';
-import { useTheme, type ThemeMode } from '../composables/useTheme';
 import SettingsDialog from './SettingsDialog.vue';
 
 const session = getSession();
 const router = useRouter();
 const { t } = useI18n();
-const { mode: themeMode, setMode } = useTheme();
 
 const settingsDialogVisible = ref(false);
 
@@ -110,32 +98,6 @@ const items = computed<NavItem[]>(() => [
 ]);
 
 const navItems = computed<NavItem[]>(() => (isLoggedIn() ? items.value : []));
-
-const themeMeta = computed<Record<ThemeMode, { label: string; icon: string }>>(() => ({
-  system: { label: t('navbar.themeModes.system'), icon: 'pi pi-desktop' },
-  light: { label: t('navbar.themeModes.light'), icon: 'pi pi-sun' },
-  dark: { label: t('navbar.themeModes.dark'), icon: 'pi pi-moon' },
-}));
-const THEME_ORDER: ThemeMode[] = ['system', 'light', 'dark'];
-
-const themeIcon = computed(() => themeMeta.value[themeMode.value].icon);
-const themeTooltip = computed(() =>
-  t('navbar.themeTooltip', { mode: themeMeta.value[themeMode.value].label }),
-);
-
-const themeMenu = ref();
-const themeItems = computed<MenuItem[]>(() =>
-  THEME_ORDER.map((value) => ({
-    label: themeMeta.value[value].label,
-    icon: themeMeta.value[value].icon,
-    class: themeMode.value === value ? 'p-menubar-item-active' : undefined,
-    command: () => setMode(value),
-  })),
-);
-
-function toggleThemeMenu(event: Event) {
-  themeMenu.value?.toggle(event);
-}
 
 const logoffMenu = ref();
 const logoffItems = computed<MenuItem[]>(() => [

--- a/web/src/components/SettingsDialog.vue
+++ b/web/src/components/SettingsDialog.vue
@@ -10,6 +10,30 @@
     <div class="flex flex-col gap-5">
       <section class="flex flex-col gap-4">
         <h3 class="text-xs font-semibold text-slate-500 uppercase tracking-wide m-0">
+          {{ $t('settings.sections.theme') }}
+        </h3>
+
+        <div class="flex flex-col gap-1">
+          <label class="text-sm font-medium">{{ $t('settings.theme.appearance') }}</label>
+          <SelectButton
+            v-model="themeChoice"
+            :options="themeOptions"
+            option-label="label"
+            option-value="value"
+            :allow-empty="false"
+            :aria-label="$t('settings.theme.appearance')"
+          >
+            <template #option="slotProps">
+              <i :class="['mr-2', slotProps.option.icon]" />
+              <span>{{ slotProps.option.label }}</span>
+            </template>
+          </SelectButton>
+          <small class="text-slate-500">{{ $t('settings.theme.hint') }}</small>
+        </div>
+      </section>
+
+      <section class="flex flex-col gap-4 pt-4 border-t border-surface-200 dark:border-surface-700">
+        <h3 class="text-xs font-semibold text-slate-500 uppercase tracking-wide m-0">
           {{ $t('settings.sections.locale') }}
         </h3>
 
@@ -88,6 +112,7 @@
 import { computed, ref, watch } from 'vue';
 import Dialog from 'primevue/dialog';
 import Select from 'primevue/select';
+import SelectButton from 'primevue/selectbutton';
 import InputText from 'primevue/inputtext';
 import Button from 'primevue/button';
 import { useI18n } from 'vue-i18n';
@@ -107,11 +132,13 @@ import {
   getStoredPageSize,
   setPageSize,
 } from '../composables/usePagination';
+import { useTheme, type ThemeMode } from '../composables/useTheme';
 
 const props = defineProps<{ visible: boolean }>();
 const emit = defineEmits<{ (e: 'close'): void }>();
 
 const { t } = useI18n();
+const { mode: themeMode, setMode: setThemeMode } = useTheme();
 
 const AUTO = '__auto';
 const CUSTOM = '__custom';
@@ -120,10 +147,12 @@ const uiChoice = ref<UiLocale | typeof AUTO>(AUTO);
 const formatChoice = ref<string>(AUTO);
 const customFormat = ref<string>('');
 const pageSizeChoice = ref<number>(DEFAULT_PAGE_SIZE);
+const themeChoice = ref<ThemeMode>(themeMode.value);
 
 const initialUi = ref<UiLocale | typeof AUTO>(AUTO);
 const initialFormat = ref<string>(AUTO);
 const initialCustomFormat = ref<string>('');
+const initialTheme = ref<ThemeMode>(themeMode.value);
 
 const uiOptions = computed(() => [
   { value: AUTO, label: `${t('settings.locale.autoOption')} (${detectUiLocale() === 'pt' ? t('settings.locale.languageOptions.pt') : t('settings.locale.languageOptions.en')})` },
@@ -140,6 +169,16 @@ const formatOptions = computed(() => [
 const pageSizeOptions = computed(() =>
   PAGE_SIZE_OPTIONS.map((n) => ({ value: n, label: String(n) })),
 );
+
+const themeOptions = computed<{ value: ThemeMode; label: string; icon: string }[]>(() => [
+  { value: 'system', label: t('settings.theme.modes.system'), icon: 'pi pi-desktop' },
+  { value: 'light', label: t('settings.theme.modes.light'), icon: 'pi pi-sun' },
+  { value: 'dark', label: t('settings.theme.modes.dark'), icon: 'pi pi-moon' },
+]);
+
+watch(themeChoice, (value) => {
+  if (themeMode.value !== value) setThemeMode(value);
+});
 
 watch(
   () => props.visible,
@@ -164,6 +203,9 @@ watch(
     initialCustomFormat.value = customFormat.value;
 
     pageSizeChoice.value = getStoredPageSize() ?? DEFAULT_PAGE_SIZE;
+
+    themeChoice.value = themeMode.value;
+    initialTheme.value = themeMode.value;
   },
   { immediate: true },
 );
@@ -242,6 +284,9 @@ function apply() {
 }
 
 function handleClose() {
+  if (themeMode.value !== initialTheme.value) {
+    setThemeMode(initialTheme.value);
+  }
   emit('close');
 }
 </script>

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -50,8 +50,6 @@ export default {
 
   navbar: {
     brand: 'Finance Control',
-    theme: 'Theme',
-    themeTooltip: 'Theme: {mode}',
     logout: 'Sign out',
     settings: 'Settings',
     items: {
@@ -62,11 +60,6 @@ export default {
       loans: 'Loans',
       categories: 'Categories',
       accounts: 'Accounts',
-    },
-    themeModes: {
-      system: 'System',
-      light: 'Light',
-      dark: 'Dark',
     },
     logoff: {
       currentSession: 'Sign out (this session)',
@@ -473,8 +466,18 @@ export default {
     apply: 'Apply',
     applyHintLocale: 'Applying language or format changes will reload the app.',
     sections: {
+      theme: 'Theme',
       locale: 'Language & format',
       pagination: 'Pagination',
+    },
+    theme: {
+      appearance: 'Appearance',
+      hint: 'System follows your operating-system preference.',
+      modes: {
+        system: 'System',
+        light: 'Light',
+        dark: 'Dark',
+      },
     },
     locale: {
       uiLanguage: 'Display language',

--- a/web/src/i18n/locales/pt.ts
+++ b/web/src/i18n/locales/pt.ts
@@ -50,8 +50,6 @@ export default {
 
   navbar: {
     brand: 'Finance Control',
-    theme: 'Tema',
-    themeTooltip: 'Tema: {mode}',
     logout: 'Sair',
     settings: 'Configurações',
     items: {
@@ -62,11 +60,6 @@ export default {
       loans: 'Empréstimos',
       categories: 'Categorias',
       accounts: 'Contas',
-    },
-    themeModes: {
-      system: 'Sistema',
-      light: 'Claro',
-      dark: 'Escuro',
     },
     logoff: {
       currentSession: 'Sair (Desta sessão)',
@@ -473,8 +466,18 @@ export default {
     apply: 'Aplicar',
     applyHintLocale: 'Ao alterar o idioma ou formato, o app será recarregado.',
     sections: {
+      theme: 'Tema',
       locale: 'Idioma e formato',
       pagination: 'Paginação',
+    },
+    theme: {
+      appearance: 'Aparência',
+      hint: 'Sistema acompanha a preferência do sistema operacional.',
+      modes: {
+        system: 'Sistema',
+        light: 'Claro',
+        dark: 'Escuro',
+      },
     },
     locale: {
       uiLanguage: 'Idioma da interface',


### PR DESCRIPTION
## Summary
- Drop the theme button + popup menu from `AppNavbar`; the top bar now keeps only avatar, settings, and sign-out.
- Add a **Theme** section to `SettingsDialog` using a `SelectButton` (System / Light / Dark, with icons), picked up at the top of the dialog above Language and Pagination.
- Theme changes apply live as the user selects, so they can preview the effect; **Cancel** (or pressing ESC) reverts to the originally-active theme. **Apply** keeps the new theme. No reload needed.
- Move `themeModes` strings from `navbar.*` to `settings.theme.*` in both `en` and `pt` locales; drop now-unused `navbar.theme`/`navbar.themeTooltip`.

## Test plan
- [ ] Open Settings — Theme section appears at the top with three icon buttons matching the current theme.
- [ ] Click Light/Dark/System — UI re-themes immediately.
- [ ] Cancel after switching — theme reverts to the value it had on open.
- [ ] Apply after switching — theme persists across reload.
- [ ] Switch UI language to `pt` and confirm Portuguese strings render in the Theme section.
- [ ] `npx vue-tsc --noEmit` clean.