### PR TITLE
Add pie-chart toggle to home category boxes

### DIFF
--- a/api/services/totalsService.js
+++ b/api/services/totalsService.js
@@ -3,6 +3,7 @@
 var mongoose = require('mongoose');
 var Accounts = require('../models/accountsModel');
 var Categories = require('../models/categoriesModel');
+var Currencies = require('../models/currenciesModel');
 var Incomes = require('../models/incomesModel');
 var Expenses = require('../models/expensesModel');
 var Transfers = require('../models/transfersModel');
@@ -19,14 +20,27 @@ function getCommonEntries(userId, callbackSuccess, callbackError) {
     //Accounts
     var accountsPromisse = Accounts.find(queryFilterUser).sort('order').exec();
     accountsPromisse.then(function (accounts) {
-        entries.accounts = accounts;
+        //Currencies (attach _currency to each account so the totals payload carries the symbol)
+        var currenciesPromisse = Currencies.find().exec();
+        currenciesPromisse.then(function (currencies) {
+            accounts.forEach(function (account) {
+                account._currency = null;
+                for (var j in currencies) {
+                    if (account.currency_id == currencies[j].id) {
+                        account._currency = currencies[j];
+                        break;
+                    }
+                }
+            });
+            entries.accounts = accounts;
 
-        //Categories
-        var categoriesPromisse = Categories.find(queryFilterUser).sort('name').exec();
-        categoriesPromisse.then(function (categories) {
-            entries.categories = categories;
+            //Categories
+            var categoriesPromisse = Categories.find(queryFilterUser).sort('name').exec();
+            categoriesPromisse.then(function (categories) {
+                entries.categories = categories;
 
-            callbackSuccess(entries);
+                callbackSuccess(entries);
+            });
         });
     })
         .then(null, function (error) {
@@ -293,7 +307,13 @@ function getAccountBalance(totals, account, status) {
 function calculateAccountsBalace(accountList, totals, status, previousAccountList) {
     var newAccounts = [];
     accountList.forEach(function (account) {
-        var newAccount = { _id: account._id, name: account.name, enabled: account.enabled };
+        var newAccount = {
+            _id: account._id,
+            name: account.name,
+            enabled: account.enabled,
+            currency_id: account.currency_id,
+            _currency: account._currency,
+        };
         newAccount.initialBalance = getAccountPreviousBalance(account, previousAccountList);
         newAccount.actualBalance = getAccountBalance(totals, newAccount, status);
         newAccounts.push(newAccount);

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@primevue/themes": "^4.2.5",
     "axios": "^1.7.9",
+    "chart.js": "^4.5.1",
     "primeicons": "^7.0.0",
     "primevue": "^4.2.5",
     "vue": "^3.5.13",

--- a/web/src/composables/useTotals.ts
+++ b/web/src/composables/useTotals.ts
@@ -7,6 +7,8 @@ export interface AccountTotal {
   enabled: boolean;
   initialBalance: number;
   actualBalance: number;
+  currency_id?: string;
+  _currency?: { _id: string; currencyCode: string } | null;
 }
 
 export interface CategoryTotal {

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -104,6 +104,9 @@ export default {
       incomes: 'Incomes',
       expenses: 'Expenses',
       empty: 'No entries in this period.',
+      viewList: 'View as list',
+      viewChart: 'View as chart',
+      others: 'Others',
     },
   },
 

--- a/web/src/i18n/locales/pt.ts
+++ b/web/src/i18n/locales/pt.ts
@@ -104,6 +104,9 @@ export default {
       incomes: 'Receitas',
       expenses: 'Despesas',
       empty: 'Nenhum lançamento no período.',
+      viewList: 'Visualizar como lista',
+      viewChart: 'Visualizar como gráfico',
+      others: 'Outros',
     },
   },
 

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -70,12 +70,14 @@
           severity="success"
           :categories="allBucket.categories"
           type="Receita"
+          storage-key="home.categoryBox.view.forecasts.incomes"
         />
         <CategoryBox
           :title="$t('home.categoryBox.expenses')"
           severity="danger"
           :categories="allBucket.categories"
           type="Despesa"
+          storage-key="home.categoryBox.view.forecasts.expenses"
         />
       </div>
     </section>
@@ -90,12 +92,14 @@
           severity="success"
           :categories="completedBucket.categories"
           type="Receita"
+          storage-key="home.categoryBox.view.cashbox.incomes"
         />
         <CategoryBox
           :title="$t('home.categoryBox.expenses')"
           severity="danger"
           :categories="completedBucket.categories"
           type="Despesa"
+          storage-key="home.categoryBox.view.cashbox.expenses"
         />
       </div>
     </section>

--- a/web/src/views/home/AccountsBox.vue
+++ b/web/src/views/home/AccountsBox.vue
@@ -21,7 +21,7 @@
         <tr v-for="account in enabledAccounts" :key="account._id">
           <td class="py-0.5 text-left">{{ account.name }}:</td>
           <td class="py-0.5 text-right tabular-nums">
-            {{ formatNumber(account.actualBalance) }}
+            {{ formatCurrency(account.actualBalance, account._currency?.currencyCode) }}
           </td>
         </tr>
       </tbody>
@@ -33,7 +33,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
 import Panel from 'primevue/panel';
-import { formatNumber } from '../../lib/dateUtils';
+import { formatCurrency } from '../../lib/dateUtils';
 import { useIsMobile } from '../../composables/useIsMobile';
 import type { AccountTotal } from '../../composables/useTotals';
 

--- a/web/src/views/home/CategoryBox.vue
+++ b/web/src/views/home/CategoryBox.vue
@@ -16,7 +16,19 @@
         {{ title }}
       </span>
     </template>
-    <table v-if="filtered.length" class="w-full text-xs">
+    <template #icons>
+      <button
+        v-if="filtered.length"
+        type="button"
+        class="p-panel-header-icon p-link"
+        :aria-label="$t(view === 'list' ? 'home.categoryBox.viewChart' : 'home.categoryBox.viewList')"
+        v-tooltip.bottom="$t(view === 'list' ? 'home.categoryBox.viewChart' : 'home.categoryBox.viewList')"
+        @click.stop="toggleView"
+      >
+        <i :class="['pi', view === 'list' ? 'pi-chart-pie' : 'pi-list', 'home-icon']" aria-hidden="true"></i>
+      </button>
+    </template>
+    <table v-if="filtered.length && view === 'list'" class="w-full text-xs">
       <tbody>
         <tr v-for="category in filtered" :key="category._id">
           <td class="py-0.5 text-left">{{ category.name }}:</td>
@@ -26,6 +38,13 @@
         </tr>
       </tbody>
     </table>
+    <Chart
+      v-else-if="filtered.length && view === 'chart'"
+      type="pie"
+      :data="chartData"
+      :options="chartOptions"
+      class="w-full"
+    />
     <p v-else class="text-xs text-slate-500">{{ $t('home.categoryBox.empty') }}</p>
   </Panel>
 </template>
@@ -33,8 +52,11 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
 import Panel from 'primevue/panel';
+import Chart from 'primevue/chart';
+import { useI18n } from 'vue-i18n';
 import { formatNumber } from '../../lib/dateUtils';
 import { useIsMobile } from '../../composables/useIsMobile';
+import { useTheme } from '../../composables/useTheme';
 import type { CategoryTotal } from '../../composables/useTotals';
 
 const props = defineProps<{
@@ -42,12 +64,16 @@ const props = defineProps<{
   severity: 'success' | 'danger';
   categories: CategoryTotal[];
   type: 'Receita' | 'Despesa';
+  storageKey: string;
 }>();
 
+const { t } = useI18n();
+
 const filtered = computed(() =>
-  props.categories.filter(
-    (c) => c.type === props.type && c.enabled && c.totalAmount > 0,
-  ),
+  props.categories
+    .filter((c) => c.type === props.type && c.enabled && c.totalAmount > 0)
+    .slice()
+    .sort((a, b) => b.totalAmount - a.totalAmount),
 );
 
 const borderClass = computed(() =>
@@ -68,10 +94,26 @@ const iconClass = computed(() =>
 
 const { isMobile } = useIsMobile();
 const collapsed = ref(isMobile.value);
+const view = ref<'list' | 'chart'>(readStoredView(props.storageKey));
 
 watch(isMobile, (mobile) => {
   collapsed.value = mobile;
 });
+
+watch(view, (next) => {
+  writeStoredView(props.storageKey, next);
+});
+
+function readStoredView(key: string): 'list' | 'chart' {
+  if (typeof window === 'undefined') return 'list';
+  const stored = window.localStorage.getItem(key);
+  return stored === 'chart' ? 'chart' : 'list';
+}
+
+function writeStoredView(key: string, value: 'list' | 'chart') {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(key, value);
+}
 
 function onHeaderClick(event: MouseEvent) {
   if (!isMobile.value) return;
@@ -79,4 +121,79 @@ function onHeaderClick(event: MouseEvent) {
   if (target?.closest('button')) return;
   collapsed.value = !collapsed.value;
 }
+
+function toggleView() {
+  view.value = view.value === 'list' ? 'chart' : 'list';
+}
+
+const PALETTE = [
+  '#3b82f6', '#ef4444', '#10b981', '#f59e0b', '#8b5cf6',
+  '#ec4899', '#14b8a6', '#f97316', '#6366f1', '#84cc16',
+  '#06b6d4', '#a855f7', '#eab308', '#22c55e', '#f43f5e',
+];
+
+const TOP_N = 9;
+
+const { isDark } = useTheme();
+
+const chartSlices = computed<{ label: string; value: number }[]>(() => {
+  const items = filtered.value;
+  if (items.length <= TOP_N + 1) {
+    return items.map((c) => ({ label: c.name, value: c.totalAmount }));
+  }
+  const top = items.slice(0, TOP_N).map((c) => ({ label: c.name, value: c.totalAmount }));
+  const othersTotal = items.slice(TOP_N).reduce((sum, c) => sum + c.totalAmount, 0);
+  return [...top, { label: t('home.categoryBox.others'), value: othersTotal }];
+});
+
+const chartData = computed(() => ({
+  labels: chartSlices.value.map((s) => s.label),
+  datasets: [
+    {
+      data: chartSlices.value.map((s) => s.value),
+      backgroundColor: chartSlices.value.map((_, i) => PALETTE[i % PALETTE.length]),
+      borderColor: isDark.value ? '#1e293b' : '#ffffff',
+      borderWidth: 2,
+    },
+  ],
+}));
+
+const chartOptions = computed(() => {
+  const textColor = isDark.value ? '#f1f5f9' : '#1e293b';
+  return {
+    responsive: true,
+    maintainAspectRatio: true,
+    color: textColor,
+    plugins: {
+      legend: {
+        position: 'bottom',
+        labels: {
+          color: textColor,
+          font: { size: 11 },
+          boxWidth: 12,
+          generateLabels: (chart: {
+            data: { labels?: string[]; datasets: { data: number[]; backgroundColor: string[]; borderColor?: string; borderWidth?: number }[] };
+          }) => {
+            const labels = chart.data.labels ?? [];
+            const dataset = chart.data.datasets[0];
+            return labels.map((label, i) => ({
+              text: `${label}: ${formatNumber(dataset.data[i])}`,
+              fillStyle: dataset.backgroundColor[i],
+              strokeStyle: dataset.borderColor ?? dataset.backgroundColor[i],
+              lineWidth: dataset.borderWidth ?? 0,
+              fontColor: textColor,
+              index: i,
+            }));
+          },
+        },
+      },
+      tooltip: {
+        callbacks: {
+          label: (ctx: { label?: string; parsed: number }) =>
+            `${ctx.label ?? ''}: ${formatNumber(ctx.parsed)}`,
+        },
+      },
+    },
+  };
+});
 </script>


### PR DESCRIPTION
## Summary
- Sort the home **Incomes** and **Expenses** category lists by amount descending.
- Add a list/chart toggle in each category box's panel header. Chart view is a pie chart (PrimeVue `Chart` + `chart.js`) with the top 9 categories by name and a 10th **Others** slice summing the rest. Legend at the bottom shows each label with its formatted value; dark-mode legend text uses high-contrast slate-100.
- Persist each panel's view selection in `localStorage` under distinct keys (`home.categoryBox.view.{forecasts,cashbox}.{incomes,expenses}`) so each box remembers its own choice.
- Show each account's currency symbol in the **Accounts** box. Required threading \`_currency\` through the \`/totals\` API: \`totalsService.getCommonEntries\` now also loads currencies and attaches them, and \`calculateAccountsBalace\` carries \`currency_id\` + \`_currency\` into the response. The frontend uses the shared \`formatCurrency\` helper.

## Test plan
- [ ] Restart the API so the new \`_currency\` field is included in \`/totals\` responses.
- [ ] Open the home page; verify Incomes and Expenses lists are sorted by amount descending in both Forecasts and Cashbox sections.
- [ ] Toggle the new chart icon in each category box; verify the pie chart renders with categories by descending amount, and that with >10 categories the 10th slice is "Others"/"Outros" with the summed total.
- [ ] Verify the legend shows \`Name: 1.234,56\` per slice and is readable in both light and dark mode.
- [ ] Toggle between list and chart on each of the 4 boxes, reload the page, and confirm each box restored its previous selection independently.
- [ ] Verify the Accounts box now displays the proper currency symbol per account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)