### PR TITLE
Make top navbar sticky on scroll

### DIFF
--- a/web/src/components/AppNavbar.vue
+++ b/web/src/components/AppNavbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <Menubar :model="navItems" class="rounded-none border-x-0 border-t-0 px-4">
+  <Menubar :model="navItems" class="sticky top-0 z-40 rounded-none border-x-0 border-t-0 px-4">
     <template #start>
       <router-link
         to="/"


### PR DESCRIPTION
## Summary
- Add `sticky top-0 z-40` to the `Menubar` so the navbar stays pinned to the top of the viewport while scrolling.

## Test plan
- [ ] Scroll down on Home, Expenses, Incomes, etc. — navbar stays visible.
- [ ] Open dialogs (Settings, form dialogs) — overlays still render above the navbar.