### PR TITLE
Fix sticky navbar on mobile

### DIFF
--- a/web/src/components/AppNavbar.vue
+++ b/web/src/components/AppNavbar.vue
@@ -1,67 +1,69 @@
 <template>
-  <Menubar :model="navItems" class="sticky top-0 z-40 rounded-none border-x-0 border-t-0 px-4">
-    <template #start>
-      <router-link
-        to="/"
-        class="flex items-center gap-2 font-semibold text-lg no-underline text-current"
-      >
-        {{ $t('navbar.brand') }}
-      </router-link>
-    </template>
-
-    <template #item="{ item, props, hasSubmenu }">
-      <router-link
-        v-if="item.to"
-        v-slot="{ href, navigate, isActive }"
-        :to="item.to"
-        custom
-      >
-        <a
-          v-bind="props.action"
-          :href="href"
-          :class="{ 'p-menubar-item-active': isActive }"
-          @click="navigate"
+  <div class="sticky top-0 z-40">
+    <Menubar :model="navItems" class="rounded-none border-x-0 border-t-0 px-4">
+      <template #start>
+        <router-link
+          to="/"
+          class="flex items-center gap-2 font-semibold text-lg no-underline text-current"
         >
+          {{ $t('navbar.brand') }}
+        </router-link>
+      </template>
+
+      <template #item="{ item, props, hasSubmenu }">
+        <router-link
+          v-if="item.to"
+          v-slot="{ href, navigate, isActive }"
+          :to="item.to"
+          custom
+        >
+          <a
+            v-bind="props.action"
+            :href="href"
+            :class="{ 'p-menubar-item-active': isActive }"
+            @click="navigate"
+          >
+            <span v-if="item.icon" :class="['p-menubar-item-icon', item.icon]" />
+            <span class="p-menubar-item-label">{{ item.label }}</span>
+          </a>
+        </router-link>
+        <a v-else v-bind="props.action" :href="item.url">
           <span v-if="item.icon" :class="['p-menubar-item-icon', item.icon]" />
           <span class="p-menubar-item-label">{{ item.label }}</span>
+          <span v-if="hasSubmenu" class="pi pi-angle-down ml-2" />
         </a>
-      </router-link>
-      <a v-else v-bind="props.action" :href="item.url">
-        <span v-if="item.icon" :class="['p-menubar-item-icon', item.icon]" />
-        <span class="p-menubar-item-label">{{ item.label }}</span>
-        <span v-if="hasSubmenu" class="pi pi-angle-down ml-2" />
-      </a>
-    </template>
+      </template>
 
-    <template #end>
-      <div v-if="session.userId" class="flex items-center gap-3">
-        <img
-          v-if="session.photo"
-          :src="session.photo"
-          :alt="session.name"
-          class="h-7 w-7 rounded-full"
-        />
-        <span class="hidden sm:inline text-sm">{{ session.name }}</span>
-        <Button
-          icon="pi pi-cog"
-          severity="secondary"
-          text
-          rounded
-          :aria-label="$t('navbar.settings')"
-          v-tooltip.bottom="$t('navbar.settings')"
-          @click="settingsDialogVisible = true"
-        />
-        <Button
-          icon="pi pi-sign-out"
-          severity="secondary"
-          text
-          :aria-label="$t('navbar.logout')"
-          @click="toggleLogoff"
-        />
-        <Menu ref="logoffMenu" :model="logoffItems" :popup="true" />
-      </div>
-    </template>
-  </Menubar>
+      <template #end>
+        <div v-if="session.userId" class="flex items-center gap-3">
+          <img
+            v-if="session.photo"
+            :src="session.photo"
+            :alt="session.name"
+            class="h-7 w-7 rounded-full"
+          />
+          <span class="hidden sm:inline text-sm">{{ session.name }}</span>
+          <Button
+            icon="pi pi-cog"
+            severity="secondary"
+            text
+            rounded
+            :aria-label="$t('navbar.settings')"
+            v-tooltip.bottom="$t('navbar.settings')"
+            @click="settingsDialogVisible = true"
+          />
+          <Button
+            icon="pi pi-sign-out"
+            severity="secondary"
+            text
+            :aria-label="$t('navbar.logout')"
+            @click="toggleLogoff"
+          />
+          <Menu ref="logoffMenu" :model="logoffItems" :popup="true" />
+        </div>
+      </template>
+    </Menubar>
+  </div>
 
   <SettingsDialog :visible="settingsDialogVisible" @close="settingsDialogVisible = false" />
 </template>


### PR DESCRIPTION
## Summary
- Sticky navbar worked on desktop but not mobile.
- Cause: PrimeVue Menubar applies `.p-menubar-mobile { position: relative }` in mobile mode, which overrides the Tailwind `sticky` utility on the Menubar's root element.
- Fix: move `sticky top-0 z-40` from the `<Menubar>` to a wrapping `<div>`. PrimeVue's mobile-mode `position: relative` only affects the Menubar element, not the wrapper.

## Test plan
- [ ] Desktop: scroll any page (Home, Expenses, etc.) — navbar stays at top
- [ ] Mobile (DevTools responsive mode <768px): scroll any page — navbar stays at top
- [ ] Mobile: tap hamburger — menu items still drop down correctly below navbar
- [ ] No regressions to active-link styling, brand link, profile/settings/logout buttons