### PR TITLE
Add toolbar search field across list views

### DIFF
--- a/web/src/composables/useSearchFilter.ts
+++ b/web/src/composables/useSearchFilter.ts
@@ -1,0 +1,30 @@
+import { computed, ref, type ComputedRef, type Ref } from 'vue';
+
+function rowMatches(row: unknown, term: string): boolean {
+  if (row == null) return false;
+  if (typeof row === 'string') return row.toLowerCase().includes(term);
+  if (typeof row === 'number' || typeof row === 'bigint') return String(row).toLowerCase().includes(term);
+  if (typeof row === 'boolean') return false;
+  if (Array.isArray(row)) return row.some((item) => rowMatches(item, term));
+  if (typeof row === 'object') {
+    return Object.values(row as Record<string, unknown>).some((value) => rowMatches(value, term));
+  }
+  return false;
+}
+
+export function useSearchFilter<T>(rows: Ref<T[]>): {
+  searchTerm: Ref<string>;
+  searchVisible: Ref<boolean>;
+  filteredRows: ComputedRef<T[]>;
+} {
+  const searchTerm = ref('');
+  const searchVisible = ref(false);
+
+  const filteredRows = computed(() => {
+    const term = searchTerm.value.trim().toLowerCase();
+    if (!term) return rows.value;
+    return rows.value.filter((row) => rowMatches(row, term));
+  });
+
+  return { searchTerm, searchVisible, filteredRows };
+}

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -134,7 +134,9 @@ export default {
       clone: 'Clone',
       pay: 'Pay',
       generate: 'Generate',
+      search: 'Search',
     },
+    searchPlaceholder: 'Search...',
     menu: {
       edit: 'Edit',
       delete: 'Delete',
@@ -213,7 +215,9 @@ export default {
       clone: 'Clone',
       receive: 'Receive',
       generate: 'Generate',
+      search: 'Search',
     },
+    searchPlaceholder: 'Search...',
     menu: {
       edit: 'Edit',
       delete: 'Delete',
@@ -285,7 +289,9 @@ export default {
       add: 'Add',
       edit: 'Edit',
       delete: 'Delete',
+      search: 'Search',
     },
+    searchPlaceholder: 'Search...',
     menu: {
       edit: 'Edit',
       delete: 'Delete',
@@ -332,7 +338,9 @@ export default {
       delete: 'Delete',
       clone: 'Clone',
       settle: 'Settle',
+      search: 'Search',
     },
+    searchPlaceholder: 'Search...',
     menu: {
       edit: 'Edit',
       delete: 'Delete',
@@ -388,7 +396,9 @@ export default {
       edit: 'Edit',
       activate: 'Activate',
       deactivate: 'Deactivate',
+      search: 'Search',
     },
+    searchPlaceholder: 'Search...',
     menu: {
       edit: 'Edit',
       activate: 'Activate',
@@ -437,7 +447,9 @@ export default {
       edit: 'Edit',
       activate: 'Activate',
       deactivate: 'Deactivate',
+      search: 'Search',
     },
+    searchPlaceholder: 'Search...',
     menu: {
       edit: 'Edit',
       activate: 'Activate',

--- a/web/src/i18n/locales/pt.ts
+++ b/web/src/i18n/locales/pt.ts
@@ -134,7 +134,9 @@ export default {
       clone: 'Clonar',
       pay: 'Pagar',
       generate: 'Gerar',
+      search: 'Pesquisar',
     },
+    searchPlaceholder: 'Pesquisar...',
     menu: {
       edit: 'Editar',
       delete: 'Excluir',
@@ -213,7 +215,9 @@ export default {
       clone: 'Clonar',
       receive: 'Receber',
       generate: 'Gerar',
+      search: 'Pesquisar',
     },
+    searchPlaceholder: 'Pesquisar...',
     menu: {
       edit: 'Editar',
       delete: 'Excluir',
@@ -285,7 +289,9 @@ export default {
       add: 'Adicionar',
       edit: 'Editar',
       delete: 'Excluir',
+      search: 'Pesquisar',
     },
+    searchPlaceholder: 'Pesquisar...',
     menu: {
       edit: 'Editar',
       delete: 'Excluir',
@@ -332,7 +338,9 @@ export default {
       delete: 'Excluir',
       clone: 'Clonar',
       settle: 'Quitar',
+      search: 'Pesquisar',
     },
+    searchPlaceholder: 'Pesquisar...',
     menu: {
       edit: 'Editar',
       delete: 'Excluir',
@@ -388,7 +396,9 @@ export default {
       edit: 'Editar',
       activate: 'Ativar',
       deactivate: 'Inativar',
+      search: 'Pesquisar',
     },
+    searchPlaceholder: 'Pesquisar...',
     menu: {
       edit: 'Editar',
       activate: 'Ativar',
@@ -437,7 +447,9 @@ export default {
       edit: 'Editar',
       activate: 'Ativar',
       deactivate: 'Inativar',
+      search: 'Pesquisar',
     },
+    searchPlaceholder: 'Pesquisar...',
     menu: {
       edit: 'Editar',
       activate: 'Ativar',

--- a/web/src/views/AccountsView.vue
+++ b/web/src/views/AccountsView.vue
@@ -4,7 +4,7 @@
 
     <Toolbar class="mb-4">
       <template #start>
-        <div class="flex gap-2">
+        <div class="flex gap-2 flex-wrap">
           <Button
             icon="pi pi-plus"
             severity="primary"
@@ -43,6 +43,23 @@
             v-tooltip.bottom="$t('accounts.tooltips.activate')"
             @click="confirmToggleFor(selected._id, true)"
           />
+          <Button
+            icon="pi pi-search"
+            :severity="searchVisible ? 'secondary' : 'primary'"
+            size="small"
+            :aria-label="$t('accounts.tooltips.search')"
+            v-tooltip.bottom="$t('accounts.tooltips.search')"
+            @click="toggleSearch"
+          />
+          <InputText
+            v-if="searchVisible"
+            v-model="searchTerm"
+            size="small"
+            class="!w-40 md:!w-56"
+            autofocus
+            :placeholder="$t('accounts.searchPlaceholder')"
+            :aria-label="$t('accounts.tooltips.search')"
+          />
         </div>
       </template>
 
@@ -57,19 +74,19 @@
     <DataTable
       v-model:selection="selected"
       v-model:context-menu-selection="selected"
-      :value="rows"
+      :value="filteredRows"
       :loading="loading"
       data-key="_id"
       selection-mode="single"
       :context-menu="!isMobile"
       removable-sort
       striped-rows
-      :paginator="rows.length > pageSize"
+      :paginator="filteredRows.length > pageSize"
       :rows="pageSize"
       class="p-datatable-sm"
       @row-contextmenu="onRowContext"
     >
-      <template #footer>{{ $t('common.records', { count: rows.length }) }}</template>
+      <template #footer>{{ $t('common.records', { count: filteredRows.length }) }}</template>
       <Column field="name" :header="$t('accounts.headers.name')" sortable />
       <Column
         field="initialBalance"
@@ -139,6 +156,7 @@ import { computed, onMounted, reactive, ref } from 'vue';
 import DataTable from 'primevue/datatable';
 import Column from 'primevue/column';
 import Button from 'primevue/button';
+import InputText from 'primevue/inputtext';
 import Toolbar from 'primevue/toolbar';
 import Checkbox from 'primevue/checkbox';
 import Menu from 'primevue/menu';
@@ -151,6 +169,7 @@ import { useAccounts, type Account, type NewAccount } from '../composables/useAc
 import { useReferenceData } from '../composables/useReferenceData';
 import { useIsMobile } from '../composables/useIsMobile';
 import { pageSize } from '../composables/usePagination';
+import { useSearchFilter } from '../composables/useSearchFilter';
 import { formatCurrency } from '../lib/dateUtils';
 import AccountFormDialog from './accounts/AccountFormDialog.vue';
 
@@ -162,6 +181,13 @@ const { isMobile } = useIsMobile();
 const { rows, loading, selected, listDisabled, fetchAll, create, update, toggleEnabled } =
   useAccounts();
 const { invalidate } = useReferenceData();
+
+const { searchTerm, searchVisible, filteredRows } = useSearchFilter(rows);
+
+function toggleSearch() {
+  searchVisible.value = !searchVisible.value;
+  if (!searchVisible.value) searchTerm.value = '';
+}
 
 const dialog = reactive<{ visible: boolean; mode: 'new' | 'edit'; accountId: string | null }>({
   visible: false,

--- a/web/src/views/CategoriesView.vue
+++ b/web/src/views/CategoriesView.vue
@@ -4,7 +4,7 @@
 
     <Toolbar class="mb-4">
       <template #start>
-        <div class="flex gap-2">
+        <div class="flex gap-2 flex-wrap">
           <Button
             icon="pi pi-plus"
             severity="primary"
@@ -43,6 +43,23 @@
             v-tooltip.bottom="$t('categories.tooltips.activate')"
             @click="confirmToggleFor(selected._id, true)"
           />
+          <Button
+            icon="pi pi-search"
+            :severity="searchVisible ? 'secondary' : 'primary'"
+            size="small"
+            :aria-label="$t('categories.tooltips.search')"
+            v-tooltip.bottom="$t('categories.tooltips.search')"
+            @click="toggleSearch"
+          />
+          <InputText
+            v-if="searchVisible"
+            v-model="searchTerm"
+            size="small"
+            class="!w-40 md:!w-56"
+            autofocus
+            :placeholder="$t('categories.searchPlaceholder')"
+            :aria-label="$t('categories.tooltips.search')"
+          />
         </div>
       </template>
 
@@ -57,19 +74,19 @@
     <DataTable
       v-model:selection="selected"
       v-model:context-menu-selection="selected"
-      :value="rows"
+      :value="filteredRows"
       :loading="loading"
       data-key="_id"
       selection-mode="single"
       :context-menu="!isMobile"
       removable-sort
       striped-rows
-      :paginator="rows.length > pageSize"
+      :paginator="filteredRows.length > pageSize"
       :rows="pageSize"
       class="p-datatable-sm"
       @row-contextmenu="onRowContext"
     >
-      <template #footer>{{ $t('common.records', { count: rows.length }) }}</template>
+      <template #footer>{{ $t('common.records', { count: filteredRows.length }) }}</template>
       <Column field="name" :header="$t('categories.headers.description')" sortable />
       <Column field="type" :header="$t('categories.headers.type')" sortable style="width: 7rem">
         <template #body="{ data }">{{ $t('enums.categoryType.' + data.type) }}</template>
@@ -121,6 +138,7 @@ import { computed, onMounted, reactive, ref } from 'vue';
 import DataTable from 'primevue/datatable';
 import Column from 'primevue/column';
 import Button from 'primevue/button';
+import InputText from 'primevue/inputtext';
 import Toolbar from 'primevue/toolbar';
 import Checkbox from 'primevue/checkbox';
 import Menu from 'primevue/menu';
@@ -132,6 +150,7 @@ import { useI18n } from 'vue-i18n';
 import { useCategories, type Category, type NewCategory } from '../composables/useCategories';
 import { useIsMobile } from '../composables/useIsMobile';
 import { pageSize } from '../composables/usePagination';
+import { useSearchFilter } from '../composables/useSearchFilter';
 import CategoryFormDialog from './categories/CategoryFormDialog.vue';
 
 const toast = useToast();
@@ -141,6 +160,13 @@ const { isMobile } = useIsMobile();
 
 const { rows, loading, selected, listDisabled, fetchAll, create, update, toggleEnabled } =
   useCategories();
+
+const { searchTerm, searchVisible, filteredRows } = useSearchFilter(rows);
+
+function toggleSearch() {
+  searchVisible.value = !searchVisible.value;
+  if (!searchVisible.value) searchTerm.value = '';
+}
 
 const dialog = reactive<{ visible: boolean; mode: 'new' | 'edit'; categoryId: string | null }>({
   visible: false,

--- a/web/src/views/ExpensesView.vue
+++ b/web/src/views/ExpensesView.vue
@@ -67,6 +67,23 @@
             v-tooltip.bottom="$t('expenses.tooltips.generate')"
             @click="generatorVisible = true"
           />
+          <Button
+            icon="pi pi-search"
+            :severity="searchVisible ? 'secondary' : 'primary'"
+            size="small"
+            :aria-label="$t('expenses.tooltips.search')"
+            v-tooltip.bottom="$t('expenses.tooltips.search')"
+            @click="toggleSearch"
+          />
+          <InputText
+            v-if="searchVisible"
+            v-model="searchTerm"
+            size="small"
+            class="!w-40 md:!w-56"
+            autofocus
+            :placeholder="$t('expenses.searchPlaceholder')"
+            :aria-label="$t('expenses.tooltips.search')"
+          />
         </div>
       </template>
 
@@ -132,14 +149,14 @@
     <DataTable
       v-model:selection="selected"
       v-model:context-menu-selection="selected"
-      :value="rows"
+      :value="filteredRows"
       :loading="loading"
       data-key="_id"
       selection-mode="single"
       :context-menu="!isMobile"
       removable-sort
       striped-rows
-      :paginator="rows.length > pageSize"
+      :paginator="filteredRows.length > pageSize"
       :rows="pageSize"
       :row-class="rowClass"
       class="p-datatable-sm"
@@ -149,7 +166,7 @@
         <template #body="{ data }">{{ formatShortDate(data.dueDate) }}</template>
       </Column>
       <Column field="description" :header="$t('expenses.headers.description')" sortable>
-        <template #footer>{{ $t('common.records', { count: rows.length }) }}</template>
+        <template #footer>{{ $t('common.records', { count: filteredRows.length }) }}</template>
       </Column>
       <Column
         field="amount"
@@ -276,6 +293,7 @@ import { computed, onMounted, reactive, ref } from 'vue';
 import DataTable from 'primevue/datatable';
 import Column from 'primevue/column';
 import Button from 'primevue/button';
+import InputText from 'primevue/inputtext';
 import Toolbar from 'primevue/toolbar';
 import DatePicker from 'primevue/datepicker';
 import Menu from 'primevue/menu';
@@ -291,6 +309,7 @@ import {
 } from '../composables/useExpenses';
 import { useIsMobile } from '../composables/useIsMobile';
 import { pageSize } from '../composables/usePagination';
+import { useSearchFilter } from '../composables/useSearchFilter';
 import {
   formatCurrency,
   formatNumber,
@@ -312,6 +331,13 @@ const { isMobile } = useIsMobile();
 
 const { rows, loading, selected, balance, fetchAll: fetchExpenses, create, update, remove, pay } =
   useExpenses();
+
+const { searchTerm, searchVisible, filteredRows } = useSearchFilter(rows);
+
+function toggleSearch() {
+  searchVisible.value = !searchVisible.value;
+  if (!searchVisible.value) searchTerm.value = '';
+}
 
 const { begin: initialBegin, end: initialEnd } = getActualMonth();
 const dueDateBegin = ref<Date | null>(initialBegin);
@@ -356,9 +382,9 @@ const rowMenuItems = computed<MenuItem[]>(() => {
   ];
 });
 
-const amountTotal = computed(() => rows.value.reduce((acc, r) => acc + (r.amount ?? 0), 0));
+const amountTotal = computed(() => filteredRows.value.reduce((acc, r) => acc + (r.amount ?? 0), 0));
 const amountPaidTotal = computed(() =>
-  rows.value.reduce((acc, r) => acc + (r.amountPaid ?? 0), 0),
+  filteredRows.value.reduce((acc, r) => acc + (r.amountPaid ?? 0), 0),
 );
 const balanceClass = computed(() => {
   if (balance.value < 0) return 'text-red-600';

--- a/web/src/views/IncomesView.vue
+++ b/web/src/views/IncomesView.vue
@@ -67,6 +67,23 @@
             v-tooltip.bottom="$t('incomes.tooltips.generate')"
             @click="generatorVisible = true"
           />
+          <Button
+            icon="pi pi-search"
+            :severity="searchVisible ? 'secondary' : 'primary'"
+            size="small"
+            :aria-label="$t('incomes.tooltips.search')"
+            v-tooltip.bottom="$t('incomes.tooltips.search')"
+            @click="toggleSearch"
+          />
+          <InputText
+            v-if="searchVisible"
+            v-model="searchTerm"
+            size="small"
+            class="!w-40 md:!w-56"
+            autofocus
+            :placeholder="$t('incomes.searchPlaceholder')"
+            :aria-label="$t('incomes.tooltips.search')"
+          />
         </div>
       </template>
 
@@ -132,14 +149,14 @@
     <DataTable
       v-model:selection="selected"
       v-model:context-menu-selection="selected"
-      :value="rows"
+      :value="filteredRows"
       :loading="loading"
       data-key="_id"
       selection-mode="single"
       :context-menu="!isMobile"
       removable-sort
       striped-rows
-      :paginator="rows.length > pageSize"
+      :paginator="filteredRows.length > pageSize"
       :rows="pageSize"
       :row-class="rowClass"
       class="p-datatable-sm"
@@ -149,7 +166,7 @@
         <template #body="{ data }">{{ formatShortDate(data.dueDate) }}</template>
       </Column>
       <Column field="description" :header="$t('incomes.headers.description')" sortable>
-        <template #footer>{{ $t('common.records', { count: rows.length }) }}</template>
+        <template #footer>{{ $t('common.records', { count: filteredRows.length }) }}</template>
       </Column>
       <Column
         field="amount"
@@ -260,6 +277,7 @@ import { computed, onMounted, reactive, ref } from 'vue';
 import DataTable from 'primevue/datatable';
 import Column from 'primevue/column';
 import Button from 'primevue/button';
+import InputText from 'primevue/inputtext';
 import Toolbar from 'primevue/toolbar';
 import DatePicker from 'primevue/datepicker';
 import Menu from 'primevue/menu';
@@ -275,6 +293,7 @@ import {
 } from '../composables/useIncomes';
 import { useIsMobile } from '../composables/useIsMobile';
 import { pageSize } from '../composables/usePagination';
+import { useSearchFilter } from '../composables/useSearchFilter';
 import {
   formatCurrency,
   formatNumber,
@@ -296,6 +315,13 @@ const { isMobile } = useIsMobile();
 
 const { rows, loading, selected, balance, fetchAll: fetchIncomes, create, update, remove, receive } =
   useIncomes();
+
+const { searchTerm, searchVisible, filteredRows } = useSearchFilter(rows);
+
+function toggleSearch() {
+  searchVisible.value = !searchVisible.value;
+  if (!searchVisible.value) searchTerm.value = '';
+}
 
 const { begin: initialBegin, end: initialEnd } = getActualMonth();
 const dueDateBegin = ref<Date | null>(initialBegin);
@@ -340,9 +366,9 @@ const rowMenuItems = computed<MenuItem[]>(() => {
   ];
 });
 
-const amountTotal = computed(() => rows.value.reduce((acc, r) => acc + (r.amount ?? 0), 0));
+const amountTotal = computed(() => filteredRows.value.reduce((acc, r) => acc + (r.amount ?? 0), 0));
 const amountReceivedTotal = computed(() =>
-  rows.value.reduce((acc, r) => acc + (r.amountReceived ?? 0), 0),
+  filteredRows.value.reduce((acc, r) => acc + (r.amountReceived ?? 0), 0),
 );
 const balanceClass = computed(() => {
   if (balance.value < 0) return 'text-red-600';

--- a/web/src/views/LoansView.vue
+++ b/web/src/views/LoansView.vue
@@ -53,6 +53,23 @@
             v-tooltip.bottom="$t('loans.tooltips.settle')"
             @click="selected && confirmPayFor(selected._id)"
           />
+          <Button
+            icon="pi pi-search"
+            :severity="searchVisible ? 'secondary' : 'primary'"
+            size="small"
+            :aria-label="$t('loans.tooltips.search')"
+            v-tooltip.bottom="$t('loans.tooltips.search')"
+            @click="toggleSearch"
+          />
+          <InputText
+            v-if="searchVisible"
+            v-model="searchTerm"
+            size="small"
+            class="!w-40 md:!w-56"
+            autofocus
+            :placeholder="$t('loans.searchPlaceholder')"
+            :aria-label="$t('loans.tooltips.search')"
+          />
         </div>
       </template>
 
@@ -67,20 +84,20 @@
     <DataTable
       v-model:selection="selected"
       v-model:context-menu-selection="selected"
-      :value="rows"
+      :value="filteredRows"
       :loading="loading"
       data-key="_id"
       selection-mode="single"
       :context-menu="!isMobile"
       removable-sort
       striped-rows
-      :paginator="rows.length > pageSize"
+      :paginator="filteredRows.length > pageSize"
       :rows="pageSize"
       class="p-datatable-sm"
       @row-contextmenu="onRowContext"
     >
       <Column field="description" :header="$t('loans.headers.description')" sortable>
-        <template #footer>{{ $t('common.records', { count: rows.length }) }}</template>
+        <template #footer>{{ $t('common.records', { count: filteredRows.length }) }}</template>
       </Column>
       <Column
         field="transactionDate"
@@ -185,6 +202,7 @@ import { computed, onMounted, reactive, ref } from 'vue';
 import DataTable from 'primevue/datatable';
 import Column from 'primevue/column';
 import Button from 'primevue/button';
+import InputText from 'primevue/inputtext';
 import Toolbar from 'primevue/toolbar';
 import Checkbox from 'primevue/checkbox';
 import Menu from 'primevue/menu';
@@ -196,6 +214,7 @@ import { useI18n } from 'vue-i18n';
 import { useLoans, type Loan, type LoanFormPayload } from '../composables/useLoans';
 import { useIsMobile } from '../composables/useIsMobile';
 import { pageSize } from '../composables/usePagination';
+import { useSearchFilter } from '../composables/useSearchFilter';
 import { formatCurrency, formatNumber, formatShortDate } from '../lib/dateUtils';
 import LoanFormDialog from './loans/LoanFormDialog.vue';
 
@@ -205,6 +224,13 @@ const { t } = useI18n();
 const { isMobile } = useIsMobile();
 
 const { rows, loading, selected, listPaid, fetchAll, create, update, remove, pay } = useLoans();
+
+const { searchTerm, searchVisible, filteredRows } = useSearchFilter(rows);
+
+function toggleSearch() {
+  searchVisible.value = !searchVisible.value;
+  if (!searchVisible.value) searchTerm.value = '';
+}
 
 const dialog = reactive<{
   visible: boolean;
@@ -247,7 +273,7 @@ const rowMenuItems = computed<MenuItem[]>(() => {
   ];
 });
 
-const amountTotal = computed(() => rows.value.reduce((acc, r) => acc + (r.amount ?? 0), 0));
+const amountTotal = computed(() => filteredRows.value.reduce((acc, r) => acc + (r.amount ?? 0), 0));
 
 onMounted(() => {
   fetchAll().catch((err) => onLoadError(extractStatus(err)));

--- a/web/src/views/TransfersView.vue
+++ b/web/src/views/TransfersView.vue
@@ -39,6 +39,23 @@
             v-tooltip.bottom="$t('transfers.tooltips.delete')"
             @click="selected && confirmDeleteFor(selected._id)"
           />
+          <Button
+            icon="pi pi-search"
+            :severity="searchVisible ? 'secondary' : 'primary'"
+            size="small"
+            :aria-label="$t('transfers.tooltips.search')"
+            v-tooltip.bottom="$t('transfers.tooltips.search')"
+            @click="toggleSearch"
+          />
+          <InputText
+            v-if="searchVisible"
+            v-model="searchTerm"
+            size="small"
+            class="!w-40 md:!w-56"
+            autofocus
+            :placeholder="$t('transfers.searchPlaceholder')"
+            :aria-label="$t('transfers.tooltips.search')"
+          />
         </div>
       </template>
 
@@ -104,21 +121,21 @@
     <DataTable
       v-model:selection="selected"
       v-model:context-menu-selection="selected"
-      :value="rows"
+      :value="filteredRows"
       :loading="loading"
       data-key="_id"
       selection-mode="single"
       :context-menu="!isMobile"
       removable-sort
       striped-rows
-      :paginator="rows.length > pageSize"
+      :paginator="filteredRows.length > pageSize"
       :rows="pageSize"
       class="p-datatable-sm"
       @row-contextmenu="onRowContext"
     >
       <Column field="date" :header="$t('transfers.headers.date')" sortable style="width: 6rem" class="text-center">
         <template #body="{ data }">{{ formatShortDate(data.date) }}</template>
-        <template #footer>{{ $t('common.records', { count: rows.length }) }}</template>
+        <template #footer>{{ $t('common.records', { count: filteredRows.length }) }}</template>
       </Column>
       <Column
         field="amount"
@@ -183,6 +200,7 @@ import { computed, onMounted, reactive, ref } from 'vue';
 import DataTable from 'primevue/datatable';
 import Column from 'primevue/column';
 import Button from 'primevue/button';
+import InputText from 'primevue/inputtext';
 import Toolbar from 'primevue/toolbar';
 import DatePicker from 'primevue/datepicker';
 import Menu from 'primevue/menu';
@@ -198,6 +216,7 @@ import {
 } from '../composables/useTransfers';
 import { useIsMobile } from '../composables/useIsMobile';
 import { pageSize } from '../composables/usePagination';
+import { useSearchFilter } from '../composables/useSearchFilter';
 import {
   formatCurrency,
   formatNumber,
@@ -217,6 +236,13 @@ const { isMobile } = useIsMobile();
 
 const { rows, loading, selected, balance, fetchAll: fetchTransfers, create, update, remove } =
   useTransfers();
+
+const { searchTerm, searchVisible, filteredRows } = useSearchFilter(rows);
+
+function toggleSearch() {
+  searchVisible.value = !searchVisible.value;
+  if (!searchVisible.value) searchTerm.value = '';
+}
 
 const { begin: initialBegin, end: initialEnd } = getActualMonth();
 const dateBegin = ref<Date | null>(initialBegin);
@@ -248,7 +274,7 @@ const rowMenuItems = computed<MenuItem[]>(() => {
   ];
 });
 
-const amountTotal = computed(() => rows.value.reduce((acc, r) => acc + (r.amount ?? 0), 0));
+const amountTotal = computed(() => filteredRows.value.reduce((acc, r) => acc + (r.amount ?? 0), 0));
 const balanceClass = computed(() => {
   if (balance.value < 0) return 'text-red-600';
   if (balance.value === 0) return 'text-slate-500';


### PR DESCRIPTION
## Summary
- Toggleable search icon button added to the action-button row on Expenses, Incomes, Transfers, Loans, Accounts, and Categories. Clicking the icon reveals an inline `InputText` next to it; clicking again hides it and clears the term.
- New `useSearchFilter` composable filters the already-fetched rows against any string/number value (case-insensitive, recursive), so it matches text columns and computed values like `_accountNames`, `_categoryNames`, `_currencyCodes`, status, amount, etc.
- Filtering is live (filters as you type) and the term persists across date pickers, month-navigation buttons, and refetches because it's a component-local ref decoupled from `fetchAll`.
- Totals (`amountTotal`, `amountPaidTotal`, `amountReceivedTotal`), the records footer, and pagination now reflect `filteredRows` instead of `rows`. The screen-level `balance` (separate API) is unaffected.

## Test plan
- [ ] On Expenses, click the search icon — input appears, focused. Type a description fragment; rows narrow live; description-column footer shows the filtered count; amount totals reflect filtered rows.
- [ ] Click month-nav `<` / `>` and `Filter` — search term remains and re-applies to the new dataset.
- [ ] Click the search icon again — input disappears and the term clears.
- [ ] Repeat smoke test on Incomes, Transfers, Loans, Accounts, Categories.
- [ ] `npx vue-tsc --noEmit` from `web/` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)