### PR TITLE
Generator scheduled flag, compact detail amount row, active navbar item

### DIFF
--- a/web/src/components/AppNavbar.vue
+++ b/web/src/components/AppNavbar.vue
@@ -13,14 +13,14 @@
       <template #item="{ item, props, hasSubmenu }">
         <router-link
           v-if="item.to"
-          v-slot="{ href, navigate, isActive }"
+          v-slot="{ href, navigate, isExactActive }"
           :to="item.to"
           custom
         >
           <a
             v-bind="props.action"
             :href="href"
-            :class="{ 'p-menubar-item-active': isActive }"
+            :class="{ 'nav-active': isExactActive }"
             @click="navigate"
           >
             <span v-if="item.icon" :class="['p-menubar-item-icon', item.icon]" />

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -57,6 +57,16 @@ body {
   }
 }
 
+/* Highlight the menubar item matching the current route */
+.p-menubar a.nav-active {
+  background-color: var(--p-menubar-item-active-background, color-mix(in srgb, var(--p-primary-color) 12%, transparent));
+  color: var(--p-menubar-item-active-color, var(--p-primary-color));
+  font-weight: 600;
+}
+.p-menubar a.nav-active .p-menubar-item-icon {
+  color: inherit;
+}
+
 /* Home: compact Card/Panel padding so both sections fit on one desktop screen */
 .home-box .p-card-body,
 .home-box .p-card-content {

--- a/web/src/views/expenses/ExpenseFormDialog.vue
+++ b/web/src/views/expenses/ExpenseFormDialog.vue
@@ -73,7 +73,12 @@
             errors.currency_id
           }}</small>
         </div>
-        <div class="col-span-8 sm:col-span-5 flex flex-col gap-1">
+        <div
+          :class="[
+            hasDetail ? 'col-span-6 sm:col-span-4' : 'col-span-8 sm:col-span-5',
+            'flex flex-col gap-1',
+          ]"
+        >
           <label for="expenseAmount" class="text-sm font-medium">{{ $t('common.fields.amount') }}</label>
           <InputNumber
             id="expenseAmount"
@@ -86,6 +91,18 @@
             input-class="text-right"
           />
           <small v-if="submitted && errors.amount" class="text-red-600">{{ errors.amount }}</small>
+        </div>
+        <div v-if="hasDetail" class="col-span-6 sm:col-span-4 flex flex-col gap-1">
+          <label for="expenseAmountPaid" class="text-sm font-medium">{{ $t('common.fields.paidAmount') }}</label>
+          <InputNumber
+            id="expenseAmountPaid"
+            v-model="form.amountPaid"
+            :min-fraction-digits="2"
+            :max-fraction-digits="2"
+            disabled
+            :locale="numberLocale"
+            input-class="text-right"
+          />
         </div>
       </div>
 
@@ -122,8 +139,8 @@
         </div>
       </div>
 
-      <div class="grid grid-cols-12 gap-3">
-        <div v-if="!hasDetail" class="col-span-12 sm:col-span-6 flex flex-col gap-1">
+      <div v-if="!hasDetail" class="grid grid-cols-12 gap-3">
+        <div class="col-span-12 sm:col-span-6 flex flex-col gap-1">
           <label for="expenseStatus" class="text-sm font-medium">{{ $t('common.fields.status') }}</label>
           <Select
             id="expenseStatus"

--- a/web/src/views/expenses/GeneratorFormDialog.vue
+++ b/web/src/views/expenses/GeneratorFormDialog.vue
@@ -140,6 +140,17 @@
         </label>
       </div>
 
+      <div class="flex items-center gap-2">
+        <Checkbox
+          v-model="form.scheduledPayment"
+          inputId="genScheduledPayment"
+          binary
+        />
+        <label for="genScheduledPayment" class="text-sm">
+          {{ $t('expenses.form.scheduledPayment') }}
+        </label>
+      </div>
+
       <div class="flex flex-col gap-1">
         <label for="genAccount" class="text-sm font-medium">{{ $t('common.fields.account') }}</label>
         <Select
@@ -248,6 +259,7 @@ const form = reactive<{
   amount: number | null;
   description: string;
   descriptionInstallmentNumber: boolean;
+  scheduledPayment: boolean;
   account_id: string;
   category_id: string;
   notes: string;
@@ -260,6 +272,7 @@ const form = reactive<{
   amount: null,
   description: '',
   descriptionInstallmentNumber: false,
+  scheduledPayment: false,
   account_id: '',
   category_id: '',
   notes: '',
@@ -310,6 +323,7 @@ watch(
       form.amount = null;
       form.description = '';
       form.descriptionInstallmentNumber = false;
+      form.scheduledPayment = false;
       form.account_id = '';
       form.category_id = '';
       form.notes = '';
@@ -339,6 +353,7 @@ async function handleSubmit() {
       amount: form.amount,
       description: form.description.trim(),
       descriptionInstallmentNumber: form.descriptionInstallmentNumber,
+      scheduledPayment: form.scheduledPayment,
       account_id: form.account_id,
       category_id: form.category_id,
       notes: form.notes ?? '',

--- a/web/src/views/incomes/IncomeFormDialog.vue
+++ b/web/src/views/incomes/IncomeFormDialog.vue
@@ -61,7 +61,12 @@
             errors.currency_id
           }}</small>
         </div>
-        <div class="col-span-8 sm:col-span-5 flex flex-col gap-1">
+        <div
+          :class="[
+            hasDetail ? 'col-span-6 sm:col-span-4' : 'col-span-8 sm:col-span-5',
+            'flex flex-col gap-1',
+          ]"
+        >
           <label for="incomeAmount" class="text-sm font-medium">{{ $t('common.fields.amount') }}</label>
           <InputNumber
             id="incomeAmount"
@@ -74,6 +79,18 @@
             input-class="text-right"
           />
           <small v-if="submitted && errors.amount" class="text-red-600">{{ errors.amount }}</small>
+        </div>
+        <div v-if="hasDetail" class="col-span-6 sm:col-span-4 flex flex-col gap-1">
+          <label for="incomeAmountReceived" class="text-sm font-medium">{{ $t('common.fields.receivedAmount') }}</label>
+          <InputNumber
+            id="incomeAmountReceived"
+            v-model="form.amountReceived"
+            :min-fraction-digits="2"
+            :max-fraction-digits="2"
+            disabled
+            :locale="numberLocale"
+            input-class="text-right"
+          />
         </div>
       </div>
 
@@ -110,8 +127,8 @@
         </div>
       </div>
 
-      <div class="grid grid-cols-12 gap-3">
-        <div v-if="!hasDetail" class="col-span-12 sm:col-span-6 flex flex-col gap-1">
+      <div v-if="!hasDetail" class="grid grid-cols-12 gap-3">
+        <div class="col-span-12 sm:col-span-6 flex flex-col gap-1">
           <label for="incomeStatus" class="text-sm font-medium">{{ $t('common.fields.status') }}</label>
           <Select
             id="incomeStatus"


### PR DESCRIPTION
## Summary
- Add a **Scheduled payment** checkbox to the expenses *Generator* dialog (the API schema already accepts `scheduledPayment` for `Despesa`, it just wasn't surfaced in the generator UI).
- In `ExpenseFormDialog` and `IncomeFormDialog`, when details exist the currency/account/category/status fields are hidden, but the remaining **Amount** and **Paid/Received amount** fields sat on different rows at mismatched widths. Move them onto the same row (half-width on mobile, third-width on desktop) so the layout uses space sensibly. The paid/received field is read-only in this state since totals are derived from details.
- Highlight the active item in the top navbar. Switched from `isActive` (which considers `/` a prefix of every route, so home was always "active") to `isExactActive`, applied a custom `nav-active` class, and styled it via `style.css`.

## Test plan
- [ ] Open *Expenses → Generate*: the new "Scheduled payment" checkbox appears, defaults to off, and round-trips through the generated expenses.
- [ ] Open an expense with details: Amount + Paid amount sit side-by-side on mobile and desktop.
- [ ] Open an income with details: Amount + Received amount sit side-by-side on mobile and desktop.
- [ ] Open an expense/income without details: previous layout is preserved (Amount on row 2 with currency, Status + Paid/Received on row 3).
- [ ] Navigate around: the navbar item for the current screen is visibly highlighted; only one item at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)