### PR TITLE
Always show toolbar search field

### DIFF
--- a/web/src/composables/useSearchFilter.ts
+++ b/web/src/composables/useSearchFilter.ts
@@ -14,11 +14,9 @@ function rowMatches(row: unknown, term: string): boolean {
 
 export function useSearchFilter<T>(rows: Ref<T[]>): {
   searchTerm: Ref<string>;
-  searchVisible: Ref<boolean>;
   filteredRows: ComputedRef<T[]>;
 } {
   const searchTerm = ref('');
-  const searchVisible = ref(false);
 
   const filteredRows = computed(() => {
     const term = searchTerm.value.trim().toLowerCase();
@@ -26,5 +24,5 @@ export function useSearchFilter<T>(rows: Ref<T[]>): {
     return rows.value.filter((row) => rowMatches(row, term));
   });
 
-  return { searchTerm, searchVisible, filteredRows };
+  return { searchTerm, filteredRows };
 }

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -134,7 +134,6 @@ export default {
       clone: 'Clone',
       pay: 'Pay',
       generate: 'Generate',
-      search: 'Search',
     },
     searchPlaceholder: 'Search...',
     menu: {
@@ -215,7 +214,6 @@ export default {
       clone: 'Clone',
       receive: 'Receive',
       generate: 'Generate',
-      search: 'Search',
     },
     searchPlaceholder: 'Search...',
     menu: {
@@ -289,7 +287,6 @@ export default {
       add: 'Add',
       edit: 'Edit',
       delete: 'Delete',
-      search: 'Search',
     },
     searchPlaceholder: 'Search...',
     menu: {
@@ -338,7 +335,6 @@ export default {
       delete: 'Delete',
       clone: 'Clone',
       settle: 'Settle',
-      search: 'Search',
     },
     searchPlaceholder: 'Search...',
     menu: {
@@ -396,7 +392,6 @@ export default {
       edit: 'Edit',
       activate: 'Activate',
       deactivate: 'Deactivate',
-      search: 'Search',
     },
     searchPlaceholder: 'Search...',
     menu: {
@@ -447,7 +442,6 @@ export default {
       edit: 'Edit',
       activate: 'Activate',
       deactivate: 'Deactivate',
-      search: 'Search',
     },
     searchPlaceholder: 'Search...',
     menu: {

--- a/web/src/i18n/locales/pt.ts
+++ b/web/src/i18n/locales/pt.ts
@@ -134,7 +134,6 @@ export default {
       clone: 'Clonar',
       pay: 'Pagar',
       generate: 'Gerar',
-      search: 'Pesquisar',
     },
     searchPlaceholder: 'Pesquisar...',
     menu: {
@@ -215,7 +214,6 @@ export default {
       clone: 'Clonar',
       receive: 'Receber',
       generate: 'Gerar',
-      search: 'Pesquisar',
     },
     searchPlaceholder: 'Pesquisar...',
     menu: {
@@ -289,7 +287,6 @@ export default {
       add: 'Adicionar',
       edit: 'Editar',
       delete: 'Excluir',
-      search: 'Pesquisar',
     },
     searchPlaceholder: 'Pesquisar...',
     menu: {
@@ -338,7 +335,6 @@ export default {
       delete: 'Excluir',
       clone: 'Clonar',
       settle: 'Quitar',
-      search: 'Pesquisar',
     },
     searchPlaceholder: 'Pesquisar...',
     menu: {
@@ -396,7 +392,6 @@ export default {
       edit: 'Editar',
       activate: 'Ativar',
       deactivate: 'Inativar',
-      search: 'Pesquisar',
     },
     searchPlaceholder: 'Pesquisar...',
     menu: {
@@ -447,7 +442,6 @@ export default {
       edit: 'Editar',
       activate: 'Ativar',
       deactivate: 'Inativar',
-      search: 'Pesquisar',
     },
     searchPlaceholder: 'Pesquisar...',
     menu: {

--- a/web/src/views/AccountsView.vue
+++ b/web/src/views/AccountsView.vue
@@ -43,22 +43,12 @@
             v-tooltip.bottom="$t('accounts.tooltips.activate')"
             @click="confirmToggleFor(selected._id, true)"
           />
-          <Button
-            icon="pi pi-search"
-            :severity="searchVisible ? 'secondary' : 'primary'"
-            size="small"
-            :aria-label="$t('accounts.tooltips.search')"
-            v-tooltip.bottom="$t('accounts.tooltips.search')"
-            @click="toggleSearch"
-          />
           <InputText
-            v-if="searchVisible"
             v-model="searchTerm"
             size="small"
             class="!w-40 md:!w-56"
-            autofocus
             :placeholder="$t('accounts.searchPlaceholder')"
-            :aria-label="$t('accounts.tooltips.search')"
+            :aria-label="$t('accounts.searchPlaceholder')"
           />
         </div>
       </template>
@@ -182,12 +172,7 @@ const { rows, loading, selected, listDisabled, fetchAll, create, update, toggleE
   useAccounts();
 const { invalidate } = useReferenceData();
 
-const { searchTerm, searchVisible, filteredRows } = useSearchFilter(rows);
-
-function toggleSearch() {
-  searchVisible.value = !searchVisible.value;
-  if (!searchVisible.value) searchTerm.value = '';
-}
+const { searchTerm, filteredRows } = useSearchFilter(rows);
 
 const dialog = reactive<{ visible: boolean; mode: 'new' | 'edit'; accountId: string | null }>({
   visible: false,

--- a/web/src/views/CategoriesView.vue
+++ b/web/src/views/CategoriesView.vue
@@ -43,22 +43,12 @@
             v-tooltip.bottom="$t('categories.tooltips.activate')"
             @click="confirmToggleFor(selected._id, true)"
           />
-          <Button
-            icon="pi pi-search"
-            :severity="searchVisible ? 'secondary' : 'primary'"
-            size="small"
-            :aria-label="$t('categories.tooltips.search')"
-            v-tooltip.bottom="$t('categories.tooltips.search')"
-            @click="toggleSearch"
-          />
           <InputText
-            v-if="searchVisible"
             v-model="searchTerm"
             size="small"
             class="!w-40 md:!w-56"
-            autofocus
             :placeholder="$t('categories.searchPlaceholder')"
-            :aria-label="$t('categories.tooltips.search')"
+            :aria-label="$t('categories.searchPlaceholder')"
           />
         </div>
       </template>
@@ -161,12 +151,7 @@ const { isMobile } = useIsMobile();
 const { rows, loading, selected, listDisabled, fetchAll, create, update, toggleEnabled } =
   useCategories();
 
-const { searchTerm, searchVisible, filteredRows } = useSearchFilter(rows);
-
-function toggleSearch() {
-  searchVisible.value = !searchVisible.value;
-  if (!searchVisible.value) searchTerm.value = '';
-}
+const { searchTerm, filteredRows } = useSearchFilter(rows);
 
 const dialog = reactive<{ visible: boolean; mode: 'new' | 'edit'; categoryId: string | null }>({
   visible: false,

--- a/web/src/views/ExpensesView.vue
+++ b/web/src/views/ExpensesView.vue
@@ -67,22 +67,12 @@
             v-tooltip.bottom="$t('expenses.tooltips.generate')"
             @click="generatorVisible = true"
           />
-          <Button
-            icon="pi pi-search"
-            :severity="searchVisible ? 'secondary' : 'primary'"
-            size="small"
-            :aria-label="$t('expenses.tooltips.search')"
-            v-tooltip.bottom="$t('expenses.tooltips.search')"
-            @click="toggleSearch"
-          />
           <InputText
-            v-if="searchVisible"
             v-model="searchTerm"
             size="small"
             class="!w-40 md:!w-56"
-            autofocus
             :placeholder="$t('expenses.searchPlaceholder')"
-            :aria-label="$t('expenses.tooltips.search')"
+            :aria-label="$t('expenses.searchPlaceholder')"
           />
         </div>
       </template>
@@ -332,12 +322,7 @@ const { isMobile } = useIsMobile();
 const { rows, loading, selected, balance, fetchAll: fetchExpenses, create, update, remove, pay } =
   useExpenses();
 
-const { searchTerm, searchVisible, filteredRows } = useSearchFilter(rows);
-
-function toggleSearch() {
-  searchVisible.value = !searchVisible.value;
-  if (!searchVisible.value) searchTerm.value = '';
-}
+const { searchTerm, filteredRows } = useSearchFilter(rows);
 
 const { begin: initialBegin, end: initialEnd } = getActualMonth();
 const dueDateBegin = ref<Date | null>(initialBegin);

--- a/web/src/views/IncomesView.vue
+++ b/web/src/views/IncomesView.vue
@@ -67,22 +67,12 @@
             v-tooltip.bottom="$t('incomes.tooltips.generate')"
             @click="generatorVisible = true"
           />
-          <Button
-            icon="pi pi-search"
-            :severity="searchVisible ? 'secondary' : 'primary'"
-            size="small"
-            :aria-label="$t('incomes.tooltips.search')"
-            v-tooltip.bottom="$t('incomes.tooltips.search')"
-            @click="toggleSearch"
-          />
           <InputText
-            v-if="searchVisible"
             v-model="searchTerm"
             size="small"
             class="!w-40 md:!w-56"
-            autofocus
             :placeholder="$t('incomes.searchPlaceholder')"
-            :aria-label="$t('incomes.tooltips.search')"
+            :aria-label="$t('incomes.searchPlaceholder')"
           />
         </div>
       </template>
@@ -316,12 +306,7 @@ const { isMobile } = useIsMobile();
 const { rows, loading, selected, balance, fetchAll: fetchIncomes, create, update, remove, receive } =
   useIncomes();
 
-const { searchTerm, searchVisible, filteredRows } = useSearchFilter(rows);
-
-function toggleSearch() {
-  searchVisible.value = !searchVisible.value;
-  if (!searchVisible.value) searchTerm.value = '';
-}
+const { searchTerm, filteredRows } = useSearchFilter(rows);
 
 const { begin: initialBegin, end: initialEnd } = getActualMonth();
 const dueDateBegin = ref<Date | null>(initialBegin);

--- a/web/src/views/LoansView.vue
+++ b/web/src/views/LoansView.vue
@@ -53,22 +53,12 @@
             v-tooltip.bottom="$t('loans.tooltips.settle')"
             @click="selected && confirmPayFor(selected._id)"
           />
-          <Button
-            icon="pi pi-search"
-            :severity="searchVisible ? 'secondary' : 'primary'"
-            size="small"
-            :aria-label="$t('loans.tooltips.search')"
-            v-tooltip.bottom="$t('loans.tooltips.search')"
-            @click="toggleSearch"
-          />
           <InputText
-            v-if="searchVisible"
             v-model="searchTerm"
             size="small"
             class="!w-40 md:!w-56"
-            autofocus
             :placeholder="$t('loans.searchPlaceholder')"
-            :aria-label="$t('loans.tooltips.search')"
+            :aria-label="$t('loans.searchPlaceholder')"
           />
         </div>
       </template>
@@ -225,12 +215,7 @@ const { isMobile } = useIsMobile();
 
 const { rows, loading, selected, listPaid, fetchAll, create, update, remove, pay } = useLoans();
 
-const { searchTerm, searchVisible, filteredRows } = useSearchFilter(rows);
-
-function toggleSearch() {
-  searchVisible.value = !searchVisible.value;
-  if (!searchVisible.value) searchTerm.value = '';
-}
+const { searchTerm, filteredRows } = useSearchFilter(rows);
 
 const dialog = reactive<{
   visible: boolean;

--- a/web/src/views/TransfersView.vue
+++ b/web/src/views/TransfersView.vue
@@ -39,22 +39,12 @@
             v-tooltip.bottom="$t('transfers.tooltips.delete')"
             @click="selected && confirmDeleteFor(selected._id)"
           />
-          <Button
-            icon="pi pi-search"
-            :severity="searchVisible ? 'secondary' : 'primary'"
-            size="small"
-            :aria-label="$t('transfers.tooltips.search')"
-            v-tooltip.bottom="$t('transfers.tooltips.search')"
-            @click="toggleSearch"
-          />
           <InputText
-            v-if="searchVisible"
             v-model="searchTerm"
             size="small"
             class="!w-40 md:!w-56"
-            autofocus
             :placeholder="$t('transfers.searchPlaceholder')"
-            :aria-label="$t('transfers.tooltips.search')"
+            :aria-label="$t('transfers.searchPlaceholder')"
           />
         </div>
       </template>
@@ -237,12 +227,7 @@ const { isMobile } = useIsMobile();
 const { rows, loading, selected, balance, fetchAll: fetchTransfers, create, update, remove } =
   useTransfers();
 
-const { searchTerm, searchVisible, filteredRows } = useSearchFilter(rows);
-
-function toggleSearch() {
-  searchVisible.value = !searchVisible.value;
-  if (!searchVisible.value) searchTerm.value = '';
-}
+const { searchTerm, filteredRows } = useSearchFilter(rows);
 
 const { begin: initialBegin, end: initialEnd } = getActualMonth();
 const dateBegin = ref<Date | null>(initialBegin);


### PR DESCRIPTION
## Summary
- Search InputText is now rendered unconditionally in the toolbar of Expenses, Incomes, Transfers, Loans, Accounts and Categories — the toggle button is gone.
- `useSearchFilter` no longer exposes `searchVisible`; `tooltips.search` strings dropped from en/pt locales.

## Test plan
- [ ] vue-tsc passes (`npx vue-tsc --noEmit` from `web/`).
- [ ] On each list view, the search field is visible by default and filters rows live as you type.
- [ ] No leftover toggle button or search tooltip text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)