### PR TITLE
Show period balance in Loans header

### DIFF
--- a/web/src/composables/useLoans.ts
+++ b/web/src/composables/useLoans.ts
@@ -1,5 +1,6 @@
 import { ref } from 'vue';
 import api from '../lib/api';
+import { getActualMonth } from '../lib/dateUtils';
 import type { Account, Currency } from './useReferenceData';
 
 export type LoanType = 'Tomado' | 'Concedido';
@@ -25,18 +26,38 @@ export type LoanFormPayload = Omit<Loan, '_id' | '_account' | '_currency'> & {
   _id?: string | null;
 };
 
+interface BalanceResponse {
+  current: {
+    all: {
+      partialBalance: number;
+    };
+  };
+}
+
+function buildCurrentMonthFilter(): string {
+  const { begin, end } = getActualMonth();
+  const startDate = new Date(begin.getFullYear(), begin.getMonth(), begin.getDate());
+  const endDate = new Date(end.getFullYear(), end.getMonth(), end.getDate(), 23, 59, 59, 999);
+  return `dateBegin=${startDate.toString()}&dateEnd=${endDate.toString()}`;
+}
+
 export function useLoans() {
   const rows = ref<Loan[]>([]);
   const loading = ref(false);
   const selected = ref<Loan | null>(null);
   const listPaid = ref(false);
+  const balance = ref<number>(0);
 
   async function fetchAll() {
     loading.value = true;
     try {
       const filter = listPaid.value ? '' : 'status=Em aberto';
-      const { data } = await api.get<Loan[]>(`/loans?${encodeURI(filter)}`);
-      rows.value = data;
+      const [loansResp, balanceResp] = await Promise.all([
+        api.get<Loan[]>(`/loans?${encodeURI(filter)}`),
+        api.get<BalanceResponse>(`/totals/balance?${buildCurrentMonthFilter()}`),
+      ]);
+      rows.value = loansResp.data;
+      balance.value = balanceResp.data?.current?.all?.partialBalance ?? 0;
       selected.value = null;
     } finally {
       loading.value = false;
@@ -70,6 +91,7 @@ export function useLoans() {
     loading,
     selected,
     listPaid,
+    balance,
     fetchAll,
     getById,
     create,

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -316,6 +316,7 @@ export default {
 
   loans: {
     title: 'Loans',
+    balanceLabel: 'Balance:',
     table: {
       empty: 'No loans found.',
     },

--- a/web/src/i18n/locales/pt.ts
+++ b/web/src/i18n/locales/pt.ts
@@ -316,6 +316,7 @@ export default {
 
   loans: {
     title: 'Cadastro de empréstimos',
+    balanceLabel: 'Saldo:',
     table: {
       empty: 'Nenhum empréstimo encontrado.',
     },

--- a/web/src/views/LoansView.vue
+++ b/web/src/views/LoansView.vue
@@ -1,6 +1,12 @@
 <template>
   <div class="container mx-auto px-4 py-6">
-    <h1 class="text-xl font-semibold mb-4">{{ $t('loans.title') }}</h1>
+    <div class="flex items-center justify-between mb-4 gap-4">
+      <h1 class="text-xl font-semibold">{{ $t('loans.title') }}</h1>
+      <div class="flex items-baseline gap-2">
+        <span class="text-sm text-slate-500">{{ $t('loans.balanceLabel') }}</span>
+        <span :class="['font-semibold', balanceClass]">{{ formatNumber(balance) }}</span>
+      </div>
+    </div>
 
     <Toolbar class="mb-4">
       <template #start>
@@ -223,7 +229,7 @@ const confirm = useConfirm();
 const { t } = useI18n();
 const { isMobile } = useIsMobile();
 
-const { rows, loading, selected, listPaid, fetchAll, create, update, remove, pay } = useLoans();
+const { rows, loading, selected, listPaid, balance, fetchAll, create, update, remove, pay } = useLoans();
 
 const { searchTerm, searchVisible, filteredRows } = useSearchFilter(rows);
 
@@ -274,6 +280,11 @@ const rowMenuItems = computed<MenuItem[]>(() => {
 });
 
 const amountTotal = computed(() => filteredRows.value.reduce((acc, r) => acc + (r.amount ?? 0), 0));
+const balanceClass = computed(() => {
+  if (balance.value < 0) return 'text-red-600';
+  if (balance.value === 0) return 'text-slate-500';
+  return 'text-green-600';
+});
 
 onMounted(() => {
   fetchAll().catch((err) => onLoadError(extractStatus(err)));


### PR DESCRIPTION
## Summary
- LoansView now mirrors Expenses/Incomes/Transfers: a `Balance` value lives top-right of the title row, color-coded by sign.
- `useLoans` fetches `/totals/balance` for the current month alongside the loans list (single Promise.all).
- Adds `loans.balanceLabel` to en/pt locales.

## Test plan
- [ ] vue-tsc passes (`npx vue-tsc --noEmit` from `web/`).
- [ ] Loans page shows the balance with the same coloring as Expenses/Incomes/Transfers for the current month.
- [ ] Balance refreshes after add/edit/delete/settle of a loan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)