### PR TITLE
Stack Amount and Paid/Received vertically below 480px on detail forms

### DIFF
--- a/web/src/components/ToolbarSearch.vue
+++ b/web/src/components/ToolbarSearch.vue
@@ -1,0 +1,78 @@
+<template>
+  <!-- >=480px: always-visible input -->
+  <InputText
+    :model-value="modelValue"
+    size="small"
+    class="hidden min-[480px]:inline-flex !w-40 md:!w-56"
+    :placeholder="placeholder"
+    :aria-label="placeholder"
+    @update:model-value="emitValue"
+  />
+
+  <!-- <480px: collapsed icon, expanded input + close button -->
+  <Button
+    v-if="!expanded"
+    class="min-[480px]:hidden"
+    icon="pi pi-search"
+    size="small"
+    :aria-label="placeholder"
+    v-tooltip.bottom="placeholder"
+    @click="expand"
+  />
+  <div v-else class="flex items-center gap-1 min-[480px]:hidden">
+    <InputText
+      ref="inputRef"
+      :model-value="modelValue"
+      size="small"
+      class="!w-40"
+      :placeholder="placeholder"
+      :aria-label="placeholder"
+      @update:model-value="emitValue"
+      @keydown.esc="collapse"
+    />
+    <Button
+      icon="pi pi-times"
+      size="small"
+      text
+      rounded
+      :aria-label="$t('common.actions.close')"
+      @click="collapse"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { nextTick, ref } from 'vue';
+import InputText from 'primevue/inputtext';
+import Button from 'primevue/button';
+
+const props = defineProps<{
+  modelValue: string;
+  placeholder: string;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string): void;
+}>();
+
+const expanded = ref(false);
+const inputRef = ref<InstanceType<typeof InputText> | null>(null);
+
+function emitValue(value: string | undefined) {
+  emit('update:modelValue', value ?? '');
+}
+
+async function expand() {
+  expanded.value = true;
+  await nextTick();
+  const el = (inputRef.value as unknown as { $el?: HTMLElement } | null)?.$el as
+    | HTMLInputElement
+    | undefined;
+  el?.focus();
+}
+
+function collapse() {
+  emit('update:modelValue', '');
+  expanded.value = false;
+}
+</script>

--- a/web/src/components/ToolbarSearch.vue
+++ b/web/src/components/ToolbarSearch.vue
@@ -1,52 +1,55 @@
 <template>
   <!-- >=480px: always-visible input -->
   <InputText
+    v-if="!isNarrow"
     :model-value="modelValue"
     size="small"
-    class="hidden min-[480px]:inline-flex !w-40 md:!w-56"
+    class="!w-40 md:!w-56"
     :placeholder="placeholder"
     :aria-label="placeholder"
     @update:model-value="emitValue"
   />
 
   <!-- <480px: collapsed icon, expanded input + close button -->
-  <Button
-    v-if="!expanded"
-    class="min-[480px]:hidden"
-    icon="pi pi-search"
-    size="small"
-    :aria-label="placeholder"
-    v-tooltip.bottom="placeholder"
-    @click="expand"
-  />
-  <div v-else class="flex items-center gap-1 min-[480px]:hidden">
-    <InputText
-      ref="inputRef"
-      :model-value="modelValue"
-      size="small"
-      class="!w-40"
-      :placeholder="placeholder"
-      :aria-label="placeholder"
-      @update:model-value="emitValue"
-      @keydown.esc="collapse"
-    />
+  <template v-else>
     <Button
-      icon="pi pi-times"
+      v-if="!expanded"
+      icon="pi pi-search"
       size="small"
-      text
-      rounded
-      :aria-label="$t('common.actions.close')"
-      @click="collapse"
+      :aria-label="placeholder"
+      v-tooltip.bottom="placeholder"
+      @click="expand"
     />
-  </div>
+    <div v-else class="flex items-center gap-1">
+      <InputText
+        ref="inputRef"
+        :model-value="modelValue"
+        size="small"
+        class="!w-40"
+        :placeholder="placeholder"
+        :aria-label="placeholder"
+        @update:model-value="emitValue"
+        @keydown.esc="collapse"
+      />
+      <Button
+        icon="pi pi-times"
+        size="small"
+        text
+        rounded
+        :aria-label="$t('common.actions.close')"
+        @click="collapse"
+      />
+    </div>
+  </template>
 </template>
 
 <script setup lang="ts">
-import { nextTick, ref } from 'vue';
+import { nextTick, ref, watch } from 'vue';
 import InputText from 'primevue/inputtext';
 import Button from 'primevue/button';
+import { useIsMobile } from '../composables/useIsMobile';
 
-const props = defineProps<{
+defineProps<{
   modelValue: string;
   placeholder: string;
 }>();
@@ -55,8 +58,13 @@ const emit = defineEmits<{
   (e: 'update:modelValue', value: string): void;
 }>();
 
+const { isMobile: isNarrow } = useIsMobile('(max-width: 479.98px)');
 const expanded = ref(false);
 const inputRef = ref<InstanceType<typeof InputText> | null>(null);
+
+watch(isNarrow, (narrow) => {
+  if (!narrow) expanded.value = false;
+});
 
 function emitValue(value: string | undefined) {
   emit('update:modelValue', value ?? '');

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -14,6 +14,7 @@ export default {
       pay: 'Pay',
       receive: 'Receive',
       settle: 'Settle',
+      close: 'Close',
     },
     fields: {
       description: 'Description',

--- a/web/src/i18n/locales/pt.ts
+++ b/web/src/i18n/locales/pt.ts
@@ -14,6 +14,7 @@ export default {
       pay: 'Pagar',
       receive: 'Receber',
       settle: 'Quitar',
+      close: 'Fechar',
     },
     fields: {
       description: 'Descrição',

--- a/web/src/views/AccountsView.vue
+++ b/web/src/views/AccountsView.vue
@@ -43,12 +43,9 @@
             v-tooltip.bottom="$t('accounts.tooltips.activate')"
             @click="confirmToggleFor(selected._id, true)"
           />
-          <InputText
+          <ToolbarSearch
             v-model="searchTerm"
-            size="small"
-            class="!w-40 md:!w-56"
             :placeholder="$t('accounts.searchPlaceholder')"
-            :aria-label="$t('accounts.searchPlaceholder')"
           />
         </div>
       </template>
@@ -146,7 +143,7 @@ import { computed, onMounted, reactive, ref } from 'vue';
 import DataTable from 'primevue/datatable';
 import Column from 'primevue/column';
 import Button from 'primevue/button';
-import InputText from 'primevue/inputtext';
+import ToolbarSearch from '../components/ToolbarSearch.vue';
 import Toolbar from 'primevue/toolbar';
 import Checkbox from 'primevue/checkbox';
 import Menu from 'primevue/menu';

--- a/web/src/views/CategoriesView.vue
+++ b/web/src/views/CategoriesView.vue
@@ -43,12 +43,9 @@
             v-tooltip.bottom="$t('categories.tooltips.activate')"
             @click="confirmToggleFor(selected._id, true)"
           />
-          <InputText
+          <ToolbarSearch
             v-model="searchTerm"
-            size="small"
-            class="!w-40 md:!w-56"
             :placeholder="$t('categories.searchPlaceholder')"
-            :aria-label="$t('categories.searchPlaceholder')"
           />
         </div>
       </template>
@@ -128,7 +125,7 @@ import { computed, onMounted, reactive, ref } from 'vue';
 import DataTable from 'primevue/datatable';
 import Column from 'primevue/column';
 import Button from 'primevue/button';
-import InputText from 'primevue/inputtext';
+import ToolbarSearch from '../components/ToolbarSearch.vue';
 import Toolbar from 'primevue/toolbar';
 import Checkbox from 'primevue/checkbox';
 import Menu from 'primevue/menu';

--- a/web/src/views/ExpensesView.vue
+++ b/web/src/views/ExpensesView.vue
@@ -67,12 +67,9 @@
             v-tooltip.bottom="$t('expenses.tooltips.generate')"
             @click="generatorVisible = true"
           />
-          <InputText
+          <ToolbarSearch
             v-model="searchTerm"
-            size="small"
-            class="!w-40 md:!w-56"
             :placeholder="$t('expenses.searchPlaceholder')"
-            :aria-label="$t('expenses.searchPlaceholder')"
           />
         </div>
       </template>
@@ -283,7 +280,7 @@ import { computed, onMounted, reactive, ref } from 'vue';
 import DataTable from 'primevue/datatable';
 import Column from 'primevue/column';
 import Button from 'primevue/button';
-import InputText from 'primevue/inputtext';
+import ToolbarSearch from '../components/ToolbarSearch.vue';
 import Toolbar from 'primevue/toolbar';
 import DatePicker from 'primevue/datepicker';
 import Menu from 'primevue/menu';

--- a/web/src/views/IncomesView.vue
+++ b/web/src/views/IncomesView.vue
@@ -67,12 +67,9 @@
             v-tooltip.bottom="$t('incomes.tooltips.generate')"
             @click="generatorVisible = true"
           />
-          <InputText
+          <ToolbarSearch
             v-model="searchTerm"
-            size="small"
-            class="!w-40 md:!w-56"
             :placeholder="$t('incomes.searchPlaceholder')"
-            :aria-label="$t('incomes.searchPlaceholder')"
           />
         </div>
       </template>
@@ -267,7 +264,7 @@ import { computed, onMounted, reactive, ref } from 'vue';
 import DataTable from 'primevue/datatable';
 import Column from 'primevue/column';
 import Button from 'primevue/button';
-import InputText from 'primevue/inputtext';
+import ToolbarSearch from '../components/ToolbarSearch.vue';
 import Toolbar from 'primevue/toolbar';
 import DatePicker from 'primevue/datepicker';
 import Menu from 'primevue/menu';

--- a/web/src/views/LoansView.vue
+++ b/web/src/views/LoansView.vue
@@ -59,12 +59,9 @@
             v-tooltip.bottom="$t('loans.tooltips.settle')"
             @click="selected && confirmPayFor(selected._id)"
           />
-          <InputText
+          <ToolbarSearch
             v-model="searchTerm"
-            size="small"
-            class="!w-40 md:!w-56"
             :placeholder="$t('loans.searchPlaceholder')"
-            :aria-label="$t('loans.searchPlaceholder')"
           />
         </div>
       </template>
@@ -198,7 +195,7 @@ import { computed, onMounted, reactive, ref } from 'vue';
 import DataTable from 'primevue/datatable';
 import Column from 'primevue/column';
 import Button from 'primevue/button';
-import InputText from 'primevue/inputtext';
+import ToolbarSearch from '../components/ToolbarSearch.vue';
 import Toolbar from 'primevue/toolbar';
 import Checkbox from 'primevue/checkbox';
 import Menu from 'primevue/menu';

--- a/web/src/views/TransfersView.vue
+++ b/web/src/views/TransfersView.vue
@@ -39,12 +39,9 @@
             v-tooltip.bottom="$t('transfers.tooltips.delete')"
             @click="selected && confirmDeleteFor(selected._id)"
           />
-          <InputText
+          <ToolbarSearch
             v-model="searchTerm"
-            size="small"
-            class="!w-40 md:!w-56"
             :placeholder="$t('transfers.searchPlaceholder')"
-            :aria-label="$t('transfers.searchPlaceholder')"
           />
         </div>
       </template>
@@ -190,7 +187,7 @@ import { computed, onMounted, reactive, ref } from 'vue';
 import DataTable from 'primevue/datatable';
 import Column from 'primevue/column';
 import Button from 'primevue/button';
-import InputText from 'primevue/inputtext';
+import ToolbarSearch from '../components/ToolbarSearch.vue';
 import Toolbar from 'primevue/toolbar';
 import DatePicker from 'primevue/datepicker';
 import Menu from 'primevue/menu';

--- a/web/src/views/expenses/ExpenseFormDialog.vue
+++ b/web/src/views/expenses/ExpenseFormDialog.vue
@@ -75,7 +75,9 @@
         </div>
         <div
           :class="[
-            hasDetail ? 'col-span-6 sm:col-span-4' : 'col-span-8 sm:col-span-5',
+            hasDetail
+              ? 'col-span-12 min-[480px]:col-span-6 sm:col-span-4'
+              : 'col-span-8 sm:col-span-5',
             'flex flex-col gap-1',
           ]"
         >
@@ -92,7 +94,7 @@
           />
           <small v-if="submitted && errors.amount" class="text-red-600">{{ errors.amount }}</small>
         </div>
-        <div v-if="hasDetail" class="col-span-6 sm:col-span-4 flex flex-col gap-1">
+        <div v-if="hasDetail" class="col-span-12 min-[480px]:col-span-6 sm:col-span-4 flex flex-col gap-1">
           <label for="expenseAmountPaid" class="text-sm font-medium">{{ $t('common.fields.paidAmount') }}</label>
           <InputNumber
             id="expenseAmountPaid"

--- a/web/src/views/expenses/ExpenseFormDialog.vue
+++ b/web/src/views/expenses/ExpenseFormDialog.vue
@@ -255,7 +255,12 @@
               <span class="block text-right">{{ formatNumber(detailTotal) }}</span>
             </template>
           </Column>
-          <Column :header="$t('common.fields.account')" style="width: 12rem">
+          <Column
+            :header="$t('common.fields.account')"
+            style="width: 12rem"
+            class="max-[534px]:hidden"
+            header-class="max-[534px]:hidden"
+          >
             <template #body="{ data }">{{ data._account?.name ?? '' }}</template>
           </Column>
           <Column :header="$t('common.fields.category')" style="width: 12rem">

--- a/web/src/views/incomes/IncomeFormDialog.vue
+++ b/web/src/views/incomes/IncomeFormDialog.vue
@@ -243,7 +243,12 @@
               <span class="block text-right">{{ formatNumber(detailTotal) }}</span>
             </template>
           </Column>
-          <Column :header="$t('common.fields.account')" style="width: 12rem">
+          <Column
+            :header="$t('common.fields.account')"
+            style="width: 12rem"
+            class="max-[534px]:hidden"
+            header-class="max-[534px]:hidden"
+          >
             <template #body="{ data }">{{ data._account?.name ?? '' }}</template>
           </Column>
           <Column :header="$t('common.fields.category')" style="width: 12rem">

--- a/web/src/views/incomes/IncomeFormDialog.vue
+++ b/web/src/views/incomes/IncomeFormDialog.vue
@@ -63,7 +63,9 @@
         </div>
         <div
           :class="[
-            hasDetail ? 'col-span-6 sm:col-span-4' : 'col-span-8 sm:col-span-5',
+            hasDetail
+              ? 'col-span-12 min-[480px]:col-span-6 sm:col-span-4'
+              : 'col-span-8 sm:col-span-5',
             'flex flex-col gap-1',
           ]"
         >
@@ -80,7 +82,7 @@
           />
           <small v-if="submitted && errors.amount" class="text-red-600">{{ errors.amount }}</small>
         </div>
-        <div v-if="hasDetail" class="col-span-6 sm:col-span-4 flex flex-col gap-1">
+        <div v-if="hasDetail" class="col-span-12 min-[480px]:col-span-6 sm:col-span-4 flex flex-col gap-1">
           <label for="incomeAmountReceived" class="text-sm font-medium">{{ $t('common.fields.receivedAmount') }}</label>
           <InputNumber
             id="incomeAmountReceived"


### PR DESCRIPTION
## Summary
- When an expense/income has details, the Amount and Paid/Received fields share a row at `col-span-6` each. Below ~480px the dialog is too narrow and the inputs visually overlap.
- Switch the two fields to `col-span-12 min-[480px]:col-span-6 sm:col-span-4` so they stack one-per-line on very narrow viewports and resume side-by-side at 480px+.
- Only affects the with-details branch — non-detail layouts already place these fields on separate rows.

## Test plan
- [ ] Open an expense with details on a viewport <480px wide and confirm Amount + Paid stack vertically without overlap.
- [ ] Resize to ≥480px and confirm they sit side-by-side again.
- [ ] Repeat for the income form (Amount + Received).
- [ ] At `sm` (≥640px), confirm the row reads DueDate / Amount / Paid|Received as before.