### PR TITLE
Move begin/end year nav button labels into i18n keys

### DIFF
--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -84,9 +84,11 @@ export default {
       currentMonth: 'Go to current month',
       nextMonth: 'Go to next month',
       endYear: 'Go to end of year',
+      beginYearLabel: '<<',
       prevMonthLabel: '-1 Month',
       currentMonthLabel: 'Current',
       nextMonthLabel: '+1 Month',
+      endYearLabel: '>>',
     },
     totals: {
       title: 'Totals',

--- a/web/src/i18n/locales/pt.ts
+++ b/web/src/i18n/locales/pt.ts
@@ -84,9 +84,11 @@ export default {
       currentMonth: 'Ir para o mês atual',
       nextMonth: 'Ir para o próximo mês',
       endYear: 'Ir para o fim do ano',
+      beginYearLabel: '<<',
       prevMonthLabel: '-1 Mês',
       currentMonthLabel: 'Atual',
       nextMonthLabel: '+1 Mês',
+      endYearLabel: '>>',
     },
     totals: {
       title: 'Totais',

--- a/web/src/views/ExpensesView.vue
+++ b/web/src/views/ExpensesView.vue
@@ -80,7 +80,7 @@
             size="small"
             severity="success"
             v-tooltip.bottom="$t('home.navigation.beginYear')"
-            label="<<"
+            :label="$t('home.navigation.beginYearLabel')"
             @click="navigate('beginYear')"
           />
           <Button
@@ -108,7 +108,7 @@
             size="small"
             severity="success"
             v-tooltip.bottom="$t('home.navigation.endYear')"
-            label=">>"
+            :label="$t('home.navigation.endYearLabel')"
             @click="navigate('endYear')"
           />
         </div>

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -7,7 +7,7 @@
             size="small"
             severity="success"
             v-tooltip.bottom="$t('home.navigation.beginYear')"
-            label="<<"
+            :label="$t('home.navigation.beginYearLabel')"
             @click="navigate('beginYear')"
           />
           <Button
@@ -35,7 +35,7 @@
             size="small"
             severity="success"
             v-tooltip.bottom="$t('home.navigation.endYear')"
-            label=">>"
+            :label="$t('home.navigation.endYearLabel')"
             @click="navigate('endYear')"
           />
         </div>

--- a/web/src/views/IncomesView.vue
+++ b/web/src/views/IncomesView.vue
@@ -80,7 +80,7 @@
             size="small"
             severity="success"
             v-tooltip.bottom="$t('home.navigation.beginYear')"
-            label="<<"
+            :label="$t('home.navigation.beginYearLabel')"
             @click="navigate('beginYear')"
           />
           <Button
@@ -108,7 +108,7 @@
             size="small"
             severity="success"
             v-tooltip.bottom="$t('home.navigation.endYear')"
-            label=">>"
+            :label="$t('home.navigation.endYearLabel')"
             @click="navigate('endYear')"
           />
         </div>

--- a/web/src/views/TransfersView.vue
+++ b/web/src/views/TransfersView.vue
@@ -52,7 +52,7 @@
             size="small"
             severity="success"
             v-tooltip.bottom="$t('home.navigation.beginYear')"
-            label="<<"
+            :label="$t('home.navigation.beginYearLabel')"
             @click="navigate('beginYear')"
           />
           <Button
@@ -80,7 +80,7 @@
             size="small"
             severity="success"
             v-tooltip.bottom="$t('home.navigation.endYear')"
-            label=">>"
+            :label="$t('home.navigation.endYearLabel')"
             @click="navigate('endYear')"
           />
         </div>


### PR DESCRIPTION
## Summary
- Audit of the Vue frontend found that the surrounding nav buttons (`-1 Month`, `Current`, `+1 Month`) flow through `$t(...)`, but the `<<` / `>>` chevron labels for the begin/end year buttons were hardcoded in 4 views (`HomeView`, `ExpensesView`, `IncomesView`, `TransfersView`).
- Added `home.navigation.beginYearLabel` and `home.navigation.endYearLabel` to both `en.ts` and `pt.ts`, and switched the four views to use them.
- Backend-originated terms (`Pago`, `Em aberto`, `Despesa`, etc.) are unchanged — to be handled separately.

## Test plan
- [ ] `npx vue-tsc --noEmit` passes (verified locally)
- [ ] Begin-year and end-year nav buttons still display `<<` / `>>` on Home, Expenses, Incomes, Transfers
- [ ] Switching language in Settings does not break the buttons